### PR TITLE
Adding SonarLint metadata attributes/descriptors

### DIFF
--- a/PluginGenerator.sln
+++ b/PluginGenerator.sln
@@ -1,4 +1,5 @@
-﻿Microsoft Visual Studio Solution File, Format Version 12.00
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
 VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
@@ -39,6 +40,8 @@ EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarQube.Plugins.Test.Common", "Tests\Common\SonarQube.Plugins.Test.Common.csproj", "{F60478FF-1EEA-4FB4-9BF4-50D11F94FA57}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests", "Tests\RoslynPluginGeneratorTests\SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj", "{AAE84E64-5977-44D7-8959-80F59FA2B0C1}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SonarLint.Metadata", "SonarLint.Metadata\SonarLint.Metadata.csproj", "{FD1E676B-A621-494B-9E2F-083940100415}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -88,6 +91,10 @@ Global
 		{AAE84E64-5977-44D7-8959-80F59FA2B0C1}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{AAE84E64-5977-44D7-8959-80F59FA2B0C1}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{AAE84E64-5977-44D7-8959-80F59FA2B0C1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FD1E676B-A621-494B-9E2F-083940100415}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FD1E676B-A621-494B-9E2F-083940100415}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FD1E676B-A621-494B-9E2F-083940100415}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FD1E676B-A621-494B-9E2F-083940100415}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/SonarLint.Metadata/Common/IdeVisibility.cs
+++ b/SonarLint.Metadata/Common/IdeVisibility.cs
@@ -1,0 +1,15 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.Common
+{
+    public enum IdeVisibility
+    {
+        Visible,
+        Hidden
+    }
+}

--- a/SonarLint.Metadata/Common/PropertyType.cs
+++ b/SonarLint.Metadata/Common/PropertyType.cs
@@ -1,0 +1,25 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.Common
+{
+    public enum PropertyType
+    {
+        String,
+        Text,
+        Password,
+        Boolean,
+        Integer,
+        Float,
+        SingleSelectList,
+        Metric,
+        License,
+        RegularExpression,
+        PropertySet,
+        UserLogin
+    }
+}

--- a/SonarLint.Metadata/Common/RuleAttribute.cs
+++ b/SonarLint.Metadata/Common/RuleAttribute.cs
@@ -1,0 +1,28 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.Common
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class RuleAttribute : Attribute
+    {
+        public string Key { get; private set; }
+        public string Title { get; private set; }
+        public Severity Severity { get; private set; }
+        public bool IsActivatedByDefault { get; private set; }
+
+        public RuleAttribute(string key, Severity severity, string title, bool isActivatedByDefault)
+        {
+            Key = key;
+            Title = title;
+            Severity = severity;
+            IsActivatedByDefault = isActivatedByDefault;
+        }
+    }
+}

--- a/SonarLint.Metadata/Common/RuleParameterAttribute.cs
+++ b/SonarLint.Metadata/Common/RuleParameterAttribute.cs
@@ -1,0 +1,41 @@
+//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Globalization;
+
+namespace SonarLint.Common
+{
+    [AttributeUsage(AttributeTargets.Property)]
+    public sealed class RuleParameterAttribute : Attribute
+    {
+        public string Key { get; private set; }
+        public string Description { get; private set; }
+        public PropertyType Type { get; private set; }
+        public string DefaultValue { get; private set; }
+
+        public RuleParameterAttribute(string key, PropertyType type, string description, string defaultValue)
+        {
+            Key = key;
+            Description = description;
+            Type = type;
+            DefaultValue = defaultValue;
+        }
+        public RuleParameterAttribute(string key, PropertyType type, string description, int defaultValue)
+            : this(key, type, description, defaultValue.ToString(CultureInfo.InvariantCulture))
+        {
+        }
+        public RuleParameterAttribute(string key, PropertyType type, string description)
+            : this(key, type, description, null)
+        {
+        }
+        public RuleParameterAttribute(string key, PropertyType type)
+            : this(key, type, null, null)
+        {
+        }
+    }
+}

--- a/SonarLint.Metadata/Common/Severity.cs
+++ b/SonarLint.Metadata/Common/Severity.cs
@@ -1,0 +1,18 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.Common
+{
+    public enum Severity
+    {
+        Info,
+        Minor,
+        Major,
+        Critical,
+        Blocker
+    }
+}

--- a/SonarLint.Metadata/Common/Sqale/SqaleConstantRemediationAttribute.cs
+++ b/SonarLint.Metadata/Common/Sqale/SqaleConstantRemediationAttribute.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.Common.Sqale
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class SqaleConstantRemediationAttribute : SqaleRemediationAttribute
+    {
+        public string Value { get; private set; }
+
+        public SqaleConstantRemediationAttribute(string value)
+        {
+            Value = value;
+        }
+    }
+}

--- a/SonarLint.Metadata/Common/Sqale/SqaleRemediationAttribute.cs
+++ b/SonarLint.Metadata/Common/Sqale/SqaleRemediationAttribute.cs
@@ -1,0 +1,17 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.Common.Sqale
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SqaleRemediationAttribute : Attribute
+    {
+        protected SqaleRemediationAttribute() { }
+    }
+}

--- a/SonarLint.Metadata/Common/Sqale/SqaleSubCharacteristic.cs
+++ b/SonarLint.Metadata/Common/Sqale/SqaleSubCharacteristic.cs
@@ -1,0 +1,55 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.Common.Sqale
+{
+    public enum SqaleSubCharacteristic
+    {
+        Modularity,
+        Transportability,
+        CompilerRelatedPortability,
+        HardwareRelatedPortability,
+        LanguageRelatedPortability,
+        OsRelatedPortability,
+        SoftwareRelatedPortability,
+        TimeZoneRelatedPortability,
+        Readability,
+        Understandability,
+        ApiAbuse,
+        Errors,
+        InputValidationAndRepresentation,
+        SecurityFeatures,
+        CpuEfficiency,
+        MemoryEfficiency,
+        NetworkUse,
+        ArchitectureChangeability,
+        DataChangeability,
+        LogicChangeability,
+        ArchitectureReliability,
+        DataReliability,
+        ExceptionHandling,
+        FaultTolerance,
+        InstructionReliability,
+        LogicReliability,
+        ResourceReliability,
+        SynchronizationReliability,
+        UnitTests,
+        IntegrationTestability,
+        UnitTestability,
+        UsabilityAccessibility,
+        UsabilityCompliance,
+        UsabilityEaseOfUse,
+        ReusabilityCompliance,
+        PortabilityCompliance,
+        MaintainabilityCompliance,
+        SecurityCompliance,
+        EfficiencyCompliance,
+        ChangeabilityCompliance,
+        ReliabilityCompliance,
+        TestabilityCompliance
+    }
+}

--- a/SonarLint.Metadata/Common/Sqale/SqaleSubCharacteristicAttribute.cs
+++ b/SonarLint.Metadata/Common/Sqale/SqaleSubCharacteristicAttribute.cs
@@ -1,0 +1,22 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+
+namespace SonarLint.Common.Sqale
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class SqaleSubCharacteristicAttribute : Attribute
+    {
+        public SqaleSubCharacteristic SubCharacteristic { get; private set; }
+
+        public SqaleSubCharacteristicAttribute(SqaleSubCharacteristic subCharacteristic)
+        {
+            SubCharacteristic = subCharacteristic;
+        }
+    }
+}

--- a/SonarLint.Metadata/Common/Tag.cs
+++ b/SonarLint.Metadata/Common/Tag.cs
@@ -1,0 +1,35 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.Common
+{
+    public static class Tag
+    {
+        public const string BadPractice = "bad-practice";
+        public const string BrainOverload = "brain-overload";
+        public const string Bug = "bug";
+        public const string Cert = "cert";
+        public const string Clumsy = "clumsy";
+        public const string Confusing = "confusing";
+        public const string Convention = "convention";
+        public const string Cwe = "cwe";
+        public const string DenialOfService = "denial-of-service";
+        public const string Design = "design";
+        public const string ErrorHandling = "error-handling";
+        public const string Misra = "misra";
+        public const string MultiThreading = "multi-threading";
+        public const string OwaspA6 = "owasp-a6";
+        public const string Performance = "performance";
+        public const string Pitfall = "pitfall";
+        public const string SansTop25Porous = "sans-top25-porous";
+        public const string Security = "security";
+        public const string Suspicious = "suspicious";
+        public const string Sql = "sql";
+        public const string Unpredictable = "unpredictable";
+        public const string Unused = "unused";
+    }
+}

--- a/SonarLint.Metadata/Common/TagsAttribute.cs
+++ b/SonarLint.Metadata/Common/TagsAttribute.cs
@@ -1,0 +1,23 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+
+namespace SonarLint.Common
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public sealed class TagsAttribute : Attribute
+    {
+        public IEnumerable<string> Tags { get; private set; }
+
+        public TagsAttribute(params string[] tags)
+        {
+            Tags = tags;
+        }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDescriptors/RuleDetail.cs
+++ b/SonarLint.Metadata/Export/RuleDescriptors/RuleDetail.cs
@@ -1,0 +1,31 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace SonarLint.RuleDescriptors
+{
+    public class RuleDetail
+    {
+        public RuleDetail()
+        {
+            Tags = new List<string>();
+            Parameters = new List<RuleParameter>();
+            CodeFixTitles = new List<string>();
+        }
+
+        public string Key { get; set; }
+        public string Title { get; set; }
+        public string Severity { get; set; }
+        public int IdeSeverity { get; set; }
+        public string Description { get; set; }
+        public List<string> Tags { get; private set; }
+        public List<RuleParameter> Parameters { get; private set; }
+        public bool IsActivatedByDefault { get; set; }
+        public SqaleDescriptor SqaleDescriptor { get; set; }
+        public List<string> CodeFixTitles { get; private set; }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDescriptors/RuleParameter.cs
+++ b/SonarLint.Metadata/Export/RuleDescriptors/RuleParameter.cs
@@ -1,0 +1,16 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.RuleDescriptors
+{
+    public class RuleParameter
+    {
+        public string Key { get; set; }
+        public string Description { get; set; }
+        public string Type { get; set; }
+        public string DefaultValue { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDescriptors/SqaleDescriptor.cs
+++ b/SonarLint.Metadata/Export/RuleDescriptors/SqaleDescriptor.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.RuleDescriptors
+{
+    public class SqaleDescriptor
+    {
+        public SqaleDescriptor()
+        {
+            Remediation = new SqaleRemediation();
+        }
+
+        public string SubCharacteristic { get; set; }
+
+        public SqaleRemediation Remediation { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDescriptors/SqaleRemediation.cs
+++ b/SonarLint.Metadata/Export/RuleDescriptors/SqaleRemediation.cs
@@ -1,0 +1,20 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System.Collections.Generic;
+
+namespace SonarLint.RuleDescriptors
+{
+    public class SqaleRemediation
+    {
+        public SqaleRemediation()
+        {
+            Properties = new List<SqaleRemediationProperty>();
+        }
+
+        public List<SqaleRemediationProperty> Properties { get; private set; }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDescriptors/SqaleRemediationProperty.cs
+++ b/SonarLint.Metadata/Export/RuleDescriptors/SqaleRemediationProperty.cs
@@ -1,0 +1,19 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+namespace SonarLint.RuleDescriptors
+{
+    public class SqaleRemediationProperty
+    {
+        public const string RemediationFunctionKey = "remediationFunction";
+        public const string ConstantRemediationFunctionValue = "CONSTANT_ISSUE";
+        public const string OffsetKey = "offset";
+
+        public string Key { get; set; }
+        public string Text { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleDetailBuilder.cs
+++ b/SonarLint.Metadata/Export/RuleDetailBuilder.cs
@@ -1,0 +1,114 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using SonarLint.Common.Sqale;
+using SonarLint.Common;
+using SonarLint.RuleDescriptors;
+
+namespace SonarLint.Utilities
+{
+    public static class RuleDetailBuilder
+    {
+        public static IEnumerable<RuleDetail> GetAllRuleDetails()
+        {
+            return new RuleFinder().GetAllAnalyzerTypes().Select(GetRuleDetail);
+        }
+
+        private static RuleDetail GetRuleDetail(Type analyzerType)
+        {
+            var rule = analyzerType.GetCustomAttributes<RuleAttribute>().Single();
+
+            var ruleDetail = new RuleDetail
+            {
+                Key = rule.Key,
+                Title = rule.Title,
+                Severity = rule.Severity.ToString(),
+                IdeSeverity = (int)rule.Severity.ToDiagnosticSeverity(),
+                IsActivatedByDefault = rule.IsActivatedByDefault,
+                Description = "Full HTML description"
+            };
+
+            GetParameters(analyzerType, ruleDetail);
+            GetTags(analyzerType, ruleDetail);
+            GetSqale(analyzerType, ruleDetail);
+
+            return ruleDetail;
+        }
+
+        private static void GetSqale(Type analyzerType, RuleDetail ruleDetail)
+        {
+            var sqaleRemediation = analyzerType.GetCustomAttributes<SqaleRemediationAttribute>().FirstOrDefault();
+
+            if (sqaleRemediation == null)
+            {
+                ruleDetail.SqaleDescriptor = null;
+                return;
+            }
+
+            var sqaleSubCharacteristic = analyzerType.GetCustomAttributes<SqaleSubCharacteristicAttribute>().First();
+            var sqaleDescriptor = new SqaleDescriptor
+            {
+                SubCharacteristic = sqaleSubCharacteristic.SubCharacteristic.ToSonarQubeString()
+            };
+            var constantRemediation = sqaleRemediation as SqaleConstantRemediationAttribute;
+            if (constantRemediation == null)
+            {
+                ruleDetail.SqaleDescriptor = sqaleDescriptor;
+                return;
+            }
+
+            sqaleDescriptor.Remediation.Properties.AddRange(new[]
+            {
+                new SqaleRemediationProperty
+                {
+                    Key = SqaleRemediationProperty.RemediationFunctionKey,
+                    Text = SqaleRemediationProperty.ConstantRemediationFunctionValue
+                },
+                new SqaleRemediationProperty
+                {
+                    Key = SqaleRemediationProperty.OffsetKey,
+                    Value = constantRemediation.Value,
+                    Text = string.Empty
+                }
+            });
+
+            ruleDetail.SqaleDescriptor = sqaleDescriptor;
+        }
+
+        private static void GetTags(Type analyzerType, RuleDetail ruleDetail)
+        {
+            var tags = analyzerType.GetCustomAttributes<TagsAttribute>().FirstOrDefault();
+            if (tags != null)
+            {
+                ruleDetail.Tags.AddRange(tags.Tags);
+            }
+        }
+
+        private static void GetParameters(Type analyzerType, RuleDetail ruleDetail)
+        {
+            var parameters = analyzerType.GetProperties()
+                .Select(p => p.GetCustomAttributes<RuleParameterAttribute>().SingleOrDefault());
+
+            foreach (var ruleParameter in parameters
+                .Where(attribute => attribute != null))
+            {
+                ruleDetail.Parameters.Add(
+                    new RuleParameter
+                    {
+                        DefaultValue = ruleParameter.DefaultValue,
+                        Description = ruleParameter.Description,
+                        Key = ruleParameter.Key,
+                        Type = ruleParameter.Type.ToSonarQubeString()
+                    });
+            }
+        }
+    }
+}

--- a/SonarLint.Metadata/Export/RuleFinder.cs
+++ b/SonarLint.Metadata/Export/RuleFinder.cs
@@ -1,0 +1,45 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarLint.Common;
+using SonarLint.Test;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace SonarLint.Utilities
+{
+    public class RuleFinder
+    {
+        private readonly List<Type> diagnosticAnalyzers;
+
+        public static IEnumerable<Assembly> GetPackagedRuleAssemblies()
+        {
+            return new[]
+            {
+                Assembly.LoadFrom(typeof(TestAnalyzer).Assembly.Location)
+            };
+        }
+
+        public RuleFinder()
+        {
+            diagnosticAnalyzers = GetPackagedRuleAssemblies()
+                .SelectMany(assembly => assembly.GetTypes())
+                .Where(t => t.IsSubclassOf(typeof(DiagnosticAnalyzer)))
+                .Where(t => t.GetCustomAttributes<RuleAttribute>().Any())
+                .ToList();
+        }
+
+        public IEnumerable<Type> GetAllAnalyzerTypes()
+        {
+            return diagnosticAnalyzers;
+        }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/QualityProfileRoot.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/QualityProfileRoot.cs
@@ -1,0 +1,32 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using SonarLint.Common;
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    [XmlRoot("profile", Namespace = "")]
+    public class QualityProfileRoot
+    {
+        public QualityProfileRoot()
+        {
+            Rules = new List<QualityProfileRuleDescriptor>();
+            Language = "cs";
+            Name = "Sonar way";
+        }
+
+        [XmlElement("language")]
+        public string Language { get; set; }
+        [XmlElement("name")]
+        public string Name { get; set; }
+
+        [XmlArray("rules")]
+        public List<QualityProfileRuleDescriptor> Rules { get; private set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/QualityProfileRuleDescriptor.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/QualityProfileRuleDescriptor.cs
@@ -1,0 +1,25 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using SonarLint.Common;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    [XmlType("rule")]
+    public class QualityProfileRuleDescriptor
+    {
+        public QualityProfileRuleDescriptor()
+        {
+            RepositoryKey = "csharpsquid";
+        }
+        [XmlElement("repositoryKey")]
+        public string RepositoryKey { get; set; }
+        [XmlElement("key")]
+        public string Key { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/RuleDescriptorRoot.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/RuleDescriptorRoot.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    [XmlRoot("rules", Namespace = "")]
+    public class RuleDescriptorRoot
+    {
+        public RuleDescriptorRoot()
+        {
+            Rules= new List<RuleDetail>();
+        }
+        [XmlElement("rule")]
+        public List<RuleDetail> Rules { get; private set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/RuleDetail.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/RuleDetail.cs
@@ -1,0 +1,82 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Collections.Generic;
+using System.Globalization;
+using System.Linq;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    public class RuleDetail
+    {
+        private const string CardinalitySingle = "SINGLE";
+
+        public static RuleDetail Convert(RuleDescriptors.RuleDetail ruleDetail)
+        {
+            return new RuleDetail
+            {
+                Key = ruleDetail.Key,
+                Title = ruleDetail.Title,
+                Severity = ruleDetail.Severity.ToUpper(CultureInfo.InvariantCulture),
+                Description = ruleDetail.Description,
+                IsActivatedByDefault = ruleDetail.IsActivatedByDefault,
+                Tags = ruleDetail.Tags,
+                Parameters = ruleDetail.Parameters.Select(
+                    parameter =>
+                        new RuleParameter
+                        {
+                            Type = parameter.Type,
+                            Key = parameter.Key,
+                            Description = parameter.Description,
+                            DefaultValue = parameter.DefaultValue
+                        }).ToList(),
+                Cardinality = CardinalitySingle
+            };
+        }
+
+        public RuleDetail()
+        {
+            Tags = new List<string>();
+            Parameters = new List<RuleParameter>();
+        }
+
+        [XmlElement("key")]
+        public string Key { get; set; }
+        [XmlElement("name")]
+        public string Title { get; set; }
+        [XmlElement("severity")]
+        public string Severity { get; set; }
+        [XmlElement("cardinality")]
+        public string Cardinality { get; set; }
+
+        [XmlIgnore]
+        public string Description { get; set; }
+        [XmlElement("description")]
+        public XmlCDataSection DescriptionCDataSection
+        {
+            get
+            {
+                return new XmlDocument().CreateCDataSection(Description);
+            }
+            set
+            {
+                Description = value == null ? "" : value.Value;
+            }
+        }
+
+        [XmlElement("tag")]
+        public List<string> Tags { get; private set; }
+
+        [XmlElement("param")]
+        public List<RuleParameter> Parameters { get; private set; }
+
+        [XmlIgnore]
+        public bool IsActivatedByDefault { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/RuleParameter.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/RuleParameter.cs
@@ -1,0 +1,39 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    public class RuleParameter
+    {
+        [XmlElement("key")]
+        public string Key { get; set; }
+        [XmlIgnore]
+        public string Description { get; set; }
+
+        [XmlElement("description")]
+        public XmlCDataSection DescriptionCDataSection
+        {
+            get
+            {
+                return new XmlDocument().CreateCDataSection(Description);
+            }
+            set
+            {
+                Description = value == null ? "" : value.Value;
+            }
+        }
+
+        [XmlElement("type")]
+        public string Type { get; set; }
+
+        [XmlElement("defaultValue")]
+        public string DefaultValue { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/SqaleDescriptor.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/SqaleDescriptor.cs
@@ -1,0 +1,49 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Linq;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    [XmlType("chc")]
+    public class SqaleDescriptor
+    {
+        public static SqaleDescriptor Convert(RuleDescriptors.RuleDetail ruleDetail)
+        {
+            return ruleDetail.SqaleDescriptor == null
+                ? null
+                : new SqaleDescriptor
+                {
+                    Remediation = new SqaleRemediation
+                    {
+                        Properties =
+                            ruleDetail.SqaleDescriptor.Remediation.Properties.Select(
+                                property => new SqaleRemediationProperty
+                                {
+                                    Key = property.Key,
+                                    Value = property.Value,
+                                    Text = property.Text
+                                }).ToList(),
+                        RuleKey = ruleDetail.Key
+                    },
+                    SubCharacteristic = ruleDetail.SqaleDescriptor.SubCharacteristic
+                };
+        }
+
+        public SqaleDescriptor()
+        {
+            Remediation = new SqaleRemediation();
+        }
+
+        [XmlElement("key")]
+        public string SubCharacteristic { get; set; }
+
+        [XmlElement("chc")]
+        public SqaleRemediation Remediation { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/SqaleRemediation.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/SqaleRemediation.cs
@@ -1,0 +1,26 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    public class SqaleRemediation
+    {
+        public SqaleRemediation()
+        {
+            Properties = new List<SqaleRemediationProperty>();
+        }
+
+        [XmlElement("rule-key")]
+        public string RuleKey { get; set; }
+
+        [XmlElement("prop")]
+        public List<SqaleRemediationProperty> Properties { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/SqaleRemediationProperty.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/SqaleRemediationProperty.cs
@@ -1,0 +1,21 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    public class SqaleRemediationProperty
+    {
+        [XmlElement("key")]
+        public string Key { get; set; }
+        [XmlElement("txt")]
+        public string Text { get; set; }
+        [XmlElement("val")]
+        public string Value { get; set; }
+    }
+}

--- a/SonarLint.Metadata/Export/XmlDescriptors/SqaleRoot.cs
+++ b/SonarLint.Metadata/Export/XmlDescriptors/SqaleRoot.cs
@@ -1,0 +1,23 @@
+﻿// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+
+using System.Collections.Generic;
+using System.Xml.Serialization;
+
+namespace SonarLint.XmlDescriptor
+{
+    [XmlRoot("sqale", Namespace = "")]
+    public class SqaleRoot
+    {
+        public SqaleRoot()
+        {
+            Sqale = new List<SqaleDescriptor>();
+        }
+        [XmlArray("chc")]
+        public List<SqaleDescriptor> Sqale { get; private set; }
+    }
+}

--- a/SonarLint.Metadata/Helpers/EnumHelper.cs
+++ b/SonarLint.Metadata/Helpers/EnumHelper.cs
@@ -1,0 +1,56 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+using System;
+using System.Text.RegularExpressions;
+
+namespace SonarLint.Common.Sqale
+{
+    public static class EnumHelper
+    {
+        public static string ToSonarQubeString(this PropertyType propertyType)
+        {
+            var parts = propertyType.ToString().SplitCamelCase();
+            return string.Join("_", parts).ToUpperInvariant();
+        }
+
+        public static string[] SplitCamelCase(this string source)
+        {
+            return Regex.Split(source, @"(?<!^)(?=[A-Z])");
+        }
+
+        public static string ToSonarQubeString(this SqaleSubCharacteristic subCharacteristic)
+        {
+            var parts = subCharacteristic.ToString().SplitCamelCase();
+            return string.Join("_", parts).ToUpperInvariant();
+        }
+
+        public static DiagnosticSeverity ToDiagnosticSeverity(this Severity severity)
+        {
+            return severity.ToDiagnosticSeverity(IdeVisibility.Visible);
+        }
+
+        public static DiagnosticSeverity ToDiagnosticSeverity(this Severity severity,
+            IdeVisibility ideVisibility)
+        {
+            switch (severity)
+            {
+                case Severity.Info:
+                    return ideVisibility == IdeVisibility.Hidden ? DiagnosticSeverity.Hidden : DiagnosticSeverity.Info;
+                case Severity.Minor:
+                    return ideVisibility == IdeVisibility.Hidden ? DiagnosticSeverity.Hidden : DiagnosticSeverity.Warning;
+                case Severity.Major:
+                case Severity.Critical:
+                case Severity.Blocker:
+                    return DiagnosticSeverity.Warning;
+                default:
+                    throw new NotSupportedException();
+            }
+        }
+    }
+}

--- a/SonarLint.Metadata/Properties/AssemblyInfo.cs
+++ b/SonarLint.Metadata/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("SonarLintAnalyzerAttributes")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("SonarLintAnalyzerAttributes")]
+[assembly: AssemblyCopyright("Copyright ©  2015")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("fd1e676b-a621-494b-9e2f-083940100415")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/SonarLint.Metadata/SonarLint.Metadata.csproj
+++ b/SonarLint.Metadata/SonarLint.Metadata.csproj
@@ -1,0 +1,106 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{FD1E676B-A621-494B-9E2F-083940100415}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>SonarLint.Metadata</RootNamespace>
+    <AssemblyName>SonarLint.Metadata</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="Microsoft.CodeAnalysis, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CodeAnalysis.Common.1.0.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+    <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.1.36.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.1.36\lib\portable-net45+win8+wp8+wpa81\System.Collections.Immutable.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Core" />
+    <Reference Include="System.Reflection.Metadata, Version=1.0.21.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Reflection.Metadata.1.0.21\lib\portable-net45+win8\System.Reflection.Metadata.dll</HintPath>
+      <Private>True</Private>
+    </Reference>
+    <Reference Include="System.Xml.Linq" />
+    <Reference Include="System.Data.DataSetExtensions" />
+    <Reference Include="Microsoft.CSharp" />
+    <Reference Include="System.Data" />
+    <Reference Include="System.Net.Http" />
+    <Reference Include="System.Xml" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Common\IdeVisibility.cs" />
+    <Compile Include="Export\RuleDescriptors\RuleDetail.cs" />
+    <Compile Include="Export\RuleDescriptors\RuleParameter.cs" />
+    <Compile Include="Export\RuleDescriptors\SqaleDescriptor.cs" />
+    <Compile Include="Export\RuleDescriptors\SqaleRemediation.cs" />
+    <Compile Include="Export\RuleDescriptors\SqaleRemediationProperty.cs" />
+    <Compile Include="Export\RuleDetailBuilder.cs" />
+    <Compile Include="Export\XmlDescriptors\QualityProfileRoot.cs" />
+    <Compile Include="Export\XmlDescriptors\QualityProfileRuleDescriptor.cs" />
+    <Compile Include="Export\XmlDescriptors\RuleDescriptorRoot.cs" />
+    <Compile Include="Export\XmlDescriptors\RuleDetail.cs" />
+    <Compile Include="Export\XmlDescriptors\RuleParameter.cs" />
+    <Compile Include="Export\XmlDescriptors\SqaleDescriptor.cs" />
+    <Compile Include="Export\XmlDescriptors\SqaleRemediation.cs" />
+    <Compile Include="Export\XmlDescriptors\SqaleRemediationProperty.cs" />
+    <Compile Include="Export\XmlDescriptors\SqaleRoot.cs" />
+    <Compile Include="Export\RuleFinder.cs" />
+    <Compile Include="Helpers\EnumHelper.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Common\PropertyType.cs" />
+    <Compile Include="Common\RuleAttribute.cs" />
+    <Compile Include="Common\RuleParameterAttribute.cs" />
+    <Compile Include="Common\Severity.cs" />
+    <Compile Include="Common\Sqale\SqaleConstantRemediationAttribute.cs" />
+    <Compile Include="Common\Sqale\SqaleRemediationAttribute.cs" />
+    <Compile Include="Common\Sqale\SqaleSubCharacteristic.cs" />
+    <Compile Include="Common\Sqale\SqaleSubCharacteristicAttribute.cs" />
+    <Compile Include="Common\Tag.cs" />
+    <Compile Include="Common\TagsAttribute.cs" />
+    <Compile Include="Test\DescriptorGenerator.cs" />
+    <Compile Include="Test\TestAnalyzer.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <Service Include="{82A7F48D-3B50-4B1E-B82E-3ADA8210C358}" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />
+    <Analyzer Include="..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.CSharp.Analyzers.dll" />
+  </ItemGroup>
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/SonarLint.Metadata/Test/DescriptorGenerator.cs
+++ b/SonarLint.Metadata/Test/DescriptorGenerator.cs
@@ -1,0 +1,88 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarLint.Utilities;
+using SonarLint.XmlDescriptor;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+using System.Xml.Serialization;
+
+namespace SonarLint
+{
+    [TestClass]
+    public class DescriptorGenerator
+    {
+        [TestMethod]
+        [TestCategory("SonarLint")]
+        public void Generate_Descriptor()
+        {
+            WriteXmlDescriptorFiles("rules.xml", "profile.xml", "sqale.xml");
+        }
+
+        private static void WriteXmlDescriptorFiles(string rulePath, string profilePath, string sqalePath)
+        {
+            var genericRuleDetails = RuleDetailBuilder.GetAllRuleDetails().ToList();
+            var ruleDetails = genericRuleDetails.Select(RuleDetail.Convert).ToList();
+            var sqaleDetails = genericRuleDetails.Select(SqaleDescriptor.Convert).ToList();
+
+            WriteRuleDescriptorFile(rulePath, ruleDetails);
+            WriteQualityProfileFile(profilePath, ruleDetails);
+            WriteSqaleDescriptorFile(sqalePath, sqaleDetails);
+        }
+
+        private static void WriteSqaleDescriptorFile(string filePath, IEnumerable<SqaleDescriptor> sqaleDescriptions)
+        {
+            var root = new SqaleRoot();
+            root.Sqale.AddRange(sqaleDescriptions
+                .Where(descriptor => descriptor != null));
+            SerializeObjectToFile(filePath, root);
+        }
+
+        private static void WriteQualityProfileFile(string filePath, IEnumerable<RuleDetail> ruleDetails)
+        {
+            var root = new QualityProfileRoot();
+            root.Rules.AddRange(ruleDetails
+                .Where(descriptor => descriptor.IsActivatedByDefault)
+                .Select(descriptor => new QualityProfileRuleDescriptor
+                {
+                    Key = descriptor.Key
+                }));
+
+            SerializeObjectToFile(filePath, root);
+        }
+
+        private static void WriteRuleDescriptorFile(string filePath, IEnumerable<RuleDetail> ruleDetails)
+        {
+            var root = new RuleDescriptorRoot();
+            root.Rules.AddRange(ruleDetails);
+            SerializeObjectToFile(filePath, root);
+        }
+
+        private static void SerializeObjectToFile(string filePath, object objectToSerialize)
+        {
+            var settings = new XmlWriterSettings
+            {
+                Indent = true,
+                Encoding = Encoding.UTF8,
+                IndentChars = "  "
+            };
+
+            using (var stream = new MemoryStream())
+            using (var writer = XmlWriter.Create(stream, settings))
+            {
+                var serializer = new XmlSerializer(objectToSerialize.GetType());
+                serializer.Serialize(writer, objectToSerialize, new XmlSerializerNamespaces(new[] { XmlQualifiedName.Empty }));
+                var ruleXml = Encoding.UTF8.GetString(stream.ToArray());
+                File.WriteAllText(filePath, ruleXml);
+            }
+        }
+    }
+}

--- a/SonarLint.Metadata/Test/TestAnalyzer.cs
+++ b/SonarLint.Metadata/Test/TestAnalyzer.cs
@@ -1,0 +1,49 @@
+﻿//-----------------------------------------------------------------------
+// <copyright file="RuleGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+//   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
+//   Licensed under the MIT License. See License.txt in the project root for license information.
+// </copyright>
+//-----------------------------------------------------------------------
+
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+using SonarLint.Common;
+using SonarLint.Common.Sqale;
+using System.Collections.Immutable;
+
+namespace SonarLint.Test
+{
+    [DiagnosticAnalyzer(LanguageNames.CSharp)]
+    [SqaleConstantRemediation("15min")]
+    [SqaleSubCharacteristic(SqaleSubCharacteristic.InstructionReliability)]
+    [Rule(DiagnosticId, RuleSeverity, Title, IsActivatedByDefault)]
+    [Tags(Tag.Bug)]
+    public class TestAnalyzer : DiagnosticAnalyzer
+    {
+        internal const string DiagnosticId = "ID1";
+        internal const string Title = "Some title";
+        internal const string Description = "Some description";
+        internal const string MessageFormat = "Some message";
+        internal const string Category = "Category";
+        internal const Severity RuleSeverity = Severity.Critical;
+        internal const bool IsActivatedByDefault = true;
+
+        internal static readonly DiagnosticDescriptor Rule =
+            new DiagnosticDescriptor(DiagnosticId, Title, MessageFormat, Category,
+                RuleSeverity.ToDiagnosticSeverity(), IsActivatedByDefault,
+                helpLinkUri: "help link",
+                description: Description);
+
+        private const int Default = 42;
+
+        [RuleParameter("someProperty", PropertyType.Integer, "Property descriptor", Default)]
+        public int Maximum { get; set; } = Default;
+
+        public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get { return ImmutableArray.Create(Rule); } }
+
+        public override void Initialize(AnalysisContext context)
+        {
+
+        }
+    }
+}

--- a/SonarLint.Metadata/packages.config
+++ b/SonarLint.Metadata/packages.config
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
+</packages>


### PR DESCRIPTION
Added all the attributes and descriptor classes into a single project: SonarLint.Metadata.

Also, in the same project there is a `Generate_Descriptor` test method, which shows a sample descriptor file generation. 

Here are the main steps
* Get all rule details
 * Get all analyzers from a given assembly (in this case it's SonarLint.Metadata.dll, which contains a `TestAnalyzer`)
 * Get all the metadata (id, title, severity, activation, HTML description, rule parameters, tags and SQALE information)
* Convert the metadata to XML files:
 * rules.xml: rule metadata (id, title, severity, activation, HTML description, rule parameters, tags)
 * profile.xml: all default enabled rules
 * sqale.xml: SQALE information in a weird XML format.

The output files are saved into the output folder of SonarLint.Metadata.