### PR TITLE
[Tehcnical] Re-organised builder code

### DIFF
--- a/PluginGenerator/PluginBuilder.cs
+++ b/PluginGenerator/PluginBuilder.cs
@@ -251,7 +251,7 @@ namespace SonarQube.Plugins
 
         private void AddCoreSources(string workingDirectory)
         {
-            SourceGenerator.CreateSourceFiles(typeof(RulesPluginGenerator).Assembly, "SonarQube.Plugins.Resources.Core.", workingDirectory, new Dictionary<string, string>());
+            SourceGenerator.CreateSourceFiles(typeof(RulesPluginBuilder).Assembly, "SonarQube.Plugins.Resources.Core.", workingDirectory, new Dictionary<string, string>());
 
             foreach (string sourceFile in Directory.GetFiles(workingDirectory, "*.java", SearchOption.AllDirectories))
             {
@@ -279,7 +279,7 @@ namespace SonarQube.Plugins
         private void AddCoreJars(string workingDirectory)
         {
             // Unpack and reference the required jar files
-            SourceGenerator.UnpackReferencedJarFiles(typeof(RulesPluginGenerator).Assembly, "SonarQube.Plugins.Resources.Core.", workingDirectory);
+            SourceGenerator.UnpackReferencedJarFiles(typeof(RulesPluginBuilder).Assembly, "SonarQube.Plugins.Resources.Core.", workingDirectory);
             foreach (string jarFile in Directory.GetFiles(workingDirectory, "*.jar"))
             {
                 this.AddReferencedJar(jarFile);

--- a/PluginGenerator/PluginDefinition.cs
+++ b/PluginGenerator/PluginDefinition.cs
@@ -38,13 +38,6 @@ namespace SonarQube.Plugins
         public string Organization { get; set; }
 
         /// <summary>
-        /// Returns additional files that should be added to the jar.
-        /// Key: relative path in jar
-        /// Value: the full path to the source file
-        /// </summary>
-        public IDictionary<string, string> AdditionalFileMap { get { return this.relativePathToFileMap; } }
-
-        /// <summary>
         /// The fully-qualified names of any classes that should
         /// be exported as SonarQube extensions
         /// </summary>

--- a/PluginGenerator/Program.cs
+++ b/PluginGenerator/Program.cs
@@ -5,12 +5,7 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using SonarQube.Plugins.Common;
-using System;
-using System.Collections.Generic;
 using System.IO;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 
 namespace SonarQube.Plugins.PluginGenerator
 {
@@ -38,14 +33,15 @@ namespace SonarQube.Plugins.PluginGenerator
             string fullNewJarFilePath = Path.Combine(Directory.GetCurrentDirectory(),
                 Path.GetFileNameWithoutExtension(pluginDefnFilePath) + ".jar");
 
+            string sqaleFilePath = null;
             if (args.Length == 3)
             {
-                string sqaleFilePath = args[2];
-                defn.AdditionalFileMap["resources/sqale.xml"] = sqaleFilePath;
+                sqaleFilePath = args[2];
             }
 
-            RulesPluginGenerator generator = new RulesPluginGenerator(new JdkWrapper(), logger);
-            generator.GeneratePlugin(defn, rulesFilePath, fullNewJarFilePath);
+            PluginBuilder builder = new PluginBuilder(logger);
+            RulesPluginBuilder.ConfigureBuilder(builder, defn, rulesFilePath, sqaleFilePath);
+            builder.Build();
 
             return SUCCESS_CODE;
         }

--- a/PluginGenerator/RulesPluginBuilder.cs
+++ b/PluginGenerator/RulesPluginBuilder.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="RulesPluginGenerator.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="RulesPluginBuilder.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -11,7 +11,7 @@ using System.IO;
 
 namespace SonarQube.Plugins
 {
-    public class RulesPluginGenerator
+    public class RulesPluginBuilder
     {
         private const string RulesExtensionClassName = "PluginRulesDefinition.class";
         private const string RulesResourcesRoot = "SonarQube.Plugins.Resources.Rules.";
@@ -19,12 +19,12 @@ namespace SonarQube.Plugins
         private readonly IJdkWrapper jdkWrapper;
         private readonly ILogger logger;
 
-        public RulesPluginGenerator(ILogger logger)
+        public RulesPluginBuilder(ILogger logger)
             :this(new JdkWrapper(), logger)
         {
         }
 
-        public RulesPluginGenerator(IJdkWrapper jdkWrapper, ILogger logger)
+        public RulesPluginBuilder(IJdkWrapper jdkWrapper, ILogger logger)
         {
             if (jdkWrapper == null)
             {
@@ -64,13 +64,47 @@ namespace SonarQube.Plugins
                 this.logger.LogWarning(UIResources.Gen_ExistingJarWillBeOvewritten);
             }
 
+            PluginBuilder builder = new PluginBuilder(jdkWrapper, logger);
+            ConfigureBuilder(builder, definition, rulesFilePath, null);
+
+
+            builder.SetJarFilePath(fullJarFilePath);
+            builder.Build();
+        }
+
+        public static void ConfigureBuilder(PluginBuilder builder, PluginDefinition definition, string rulesFilePath, string sqaleFilePath)
+        {
+            if (builder == null)
+            {
+                throw new ArgumentNullException("builder");
+            }
+            if (definition == null)
+            {
+                throw new ArgumentNullException("definition");
+            }
+            if (string.IsNullOrWhiteSpace(rulesFilePath))
+            {
+                throw new ArgumentNullException("rulesFilePath");
+            }
+
+            if (!File.Exists(rulesFilePath))
+            {
+                throw new FileNotFoundException(UIResources.Gen_Error_RulesFileDoesNotExists, rulesFilePath);
+            }
+
+            if (!string.IsNullOrEmpty(sqaleFilePath) && !File.Exists(sqaleFilePath))
+            {
+                throw new FileNotFoundException(UIResources.Gen_Error_SqaleFileDoesNotExists, sqaleFilePath);
+            }
+
+            // TODO: consider moving; not specific to rules plugins
             ValidateDefinition(definition);
 
             // Temp folder which resources will be unpacked into
             string tempWorkingDir = Path.Combine(Path.GetTempPath(), ".plugins", Guid.NewGuid().ToString());
             Directory.CreateDirectory(tempWorkingDir);
 
-            BuildPlugin(definition, rulesFilePath, fullJarFilePath, tempWorkingDir);
+            DoConfigureBuilder(builder, definition, rulesFilePath, sqaleFilePath, tempWorkingDir);
         }
 
         private static void ValidateDefinition(PluginDefinition definition)
@@ -91,33 +125,29 @@ namespace SonarQube.Plugins
             }
         }
 
-        private void BuildPlugin(PluginDefinition definition, string rulesFilePath, string fullJarPath, string workingFolder)
+        private static void DoConfigureBuilder(PluginBuilder builder, PluginDefinition definition, string rulesFilePath, string sqaleFilePath, string workingFolder)
         {
-            PluginBuilder builder = new PluginBuilder(this.jdkWrapper, this.logger);
-
             AddRuleSources(workingFolder, builder);
             ConfigureSourceFileReplacements(definition, builder);
             builder.AddExtension(RulesExtensionClassName);
 
             AddRuleJars(workingFolder, builder);
 
-            // Add any additional files to the jar
-            foreach(KeyValuePair<string, string> kvp in definition.AdditionalFileMap)
+            // Add the rules and sqale files as resources
+            builder.AddResourceFile(rulesFilePath, "resources/rules.xml");
+
+            if (!string.IsNullOrEmpty(sqaleFilePath))
             {
-                builder.AddResourceFile(kvp.Value, kvp.Key);
+                builder.AddResourceFile(rulesFilePath, "resources/sqale.xml");
             }
 
-            // Add the rules file as a resource
-            builder.AddResourceFile(rulesFilePath, "resources/rules.xml");
+            // TODO: consider moving - not specific to the rules plugin
             builder.SetProperties(definition);
-            builder.SetJarFilePath(fullJarPath);
-
-            builder.Build();
         }
 
-        private void AddRuleSources(string workingDirectory, PluginBuilder builder)
+        private static void AddRuleSources(string workingDirectory, PluginBuilder builder)
         {
-            SourceGenerator.CreateSourceFiles(typeof(RulesPluginGenerator).Assembly, RulesResourcesRoot, workingDirectory, new Dictionary<string, string>());
+            SourceGenerator.CreateSourceFiles(typeof(RulesPluginBuilder).Assembly, RulesResourcesRoot, workingDirectory, new Dictionary<string, string>());
 
             foreach (string sourceFile in Directory.GetFiles(workingDirectory, "*.java", SearchOption.AllDirectories))
             {
@@ -130,15 +160,14 @@ namespace SonarQube.Plugins
             builder.SetSourceCodeTokenReplacement(WellKnownSourceCodeTokens.Rule_Language, definition.Language);
         }
 
-        private void AddRuleJars(string workingDirectory, PluginBuilder builder)
+        private static void AddRuleJars(string workingDirectory, PluginBuilder builder)
         {
             // Unpack and reference the required jar files
-            SourceGenerator.UnpackReferencedJarFiles(typeof(RulesPluginGenerator).Assembly, RulesResourcesRoot, workingDirectory);
+            SourceGenerator.UnpackReferencedJarFiles(typeof(RulesPluginBuilder).Assembly, RulesResourcesRoot, workingDirectory);
             foreach (string jarFile in Directory.GetFiles(workingDirectory, "*.jar"))
             {
                 builder.AddReferencedJar(jarFile);
             }
         }
-
     }
 }

--- a/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
+++ b/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
@@ -49,7 +49,7 @@
     <Compile Include="Interfaces\IJdkWrapper.cs" />
     <Compile Include="NuGet\DataModel.cs" />
     <Compile Include="NuGet\NuGetSpecReader.cs" />
-    <Compile Include="RulesPluginGenerator.cs" />
+    <Compile Include="RulesPluginBuilder.cs" />
     <Compile Include="JarBuilder.cs" />
     <Compile Include="JavaCompilationBuilder.cs" />
     <Compile Include="JdkWrapper.cs" />

--- a/PluginGenerator/UIResources.Designer.cs
+++ b/PluginGenerator/UIResources.Designer.cs
@@ -127,6 +127,15 @@ namespace SonarQube.Plugins {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified sqale file does not exist: {0}.
+        /// </summary>
+        internal static string Gen_Error_SqaleFileDoesNotExists {
+            get {
+                return ResourceManager.GetString("Gen_Error_SqaleFileDoesNotExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The existing jar file will be overwritten.
         /// </summary>
         internal static string Gen_ExistingJarWillBeOvewritten {

--- a/PluginGenerator/UIResources.resx
+++ b/PluginGenerator/UIResources.resx
@@ -171,4 +171,7 @@
   <data name="CoreBuilder_PluginNameIsRequired" xml:space="preserve">
     <value>The plugin name must be specified</value>
   </data>
+  <data name="Gen_Error_SqaleFileDoesNotExists" xml:space="preserve">
+    <value>The specified sqale file does not exist: {0}</value>
+  </data>
 </root>

--- a/Tests/PluginGeneratorTests/RulesPluginGeneratorTests.cs
+++ b/Tests/PluginGeneratorTests/RulesPluginGeneratorTests.cs
@@ -26,7 +26,7 @@ namespace SonarQube.Plugins.PluginGeneratorTests
             string rulesXmlFilePath = TestUtils.CreateTextFile("rules.xml", inputDir, "<xml Rules />");
 
             IJdkWrapper jdkWrapper = new JdkWrapper();
-            RulesPluginGenerator generator = new RulesPluginGenerator(jdkWrapper, new TestLogger());
+            RulesPluginBuilder generator = new RulesPluginBuilder(jdkWrapper, new TestLogger());
 
             PluginDefinition defn = new PluginDefinition()
             {
@@ -37,7 +37,7 @@ namespace SonarQube.Plugins.PluginGeneratorTests
                 Version = "0.1-SNAPSHOT",
                 Organization = "ACME Software Ltd",
                 License = "Commercial",
-                Developers = typeof(RulesPluginGenerator).FullName
+                Developers = typeof(RulesPluginBuilder).FullName
             };
 
             generator.GeneratePlugin(defn, rulesXmlFilePath, fullJarFilePath);


### PR DESCRIPTION
Changed the RulesPluginGenerator so it configures the core PluginBuilder rather than wrapping it.

This change is preparation for the addition of property definitions for Roslyn analyzers.