### PR TITLE
[Technical] Refactored the builder code

### DIFF
--- a/Common/Utilities.cs
+++ b/Common/Utilities.cs
@@ -33,5 +33,22 @@ namespace SonarQube.Plugins.Common
             Directory.CreateDirectory(newPath);
             return newPath;
         }
+
+        public static string CreateSubDirectory(string parent, string child)
+        {
+            if (string.IsNullOrWhiteSpace(parent))
+            {
+                throw new ArgumentNullException("parent");
+            }
+            if (string.IsNullOrWhiteSpace(child))
+            {
+                throw new ArgumentNullException("child");
+            }
+
+            string newDir = Path.Combine(parent, child);
+            Directory.CreateDirectory(newDir);
+            return newDir;
+        }
+
     }
 }

--- a/PluginGenerator/PluginBuilder.cs
+++ b/PluginGenerator/PluginBuilder.cs
@@ -39,7 +39,7 @@ namespace SonarQube.Plugins
         private const string ExtensionListToken = "[CORE_EXTENSION_CLASS_LIST]";
 
         private readonly IJdkWrapper jdkWrapper;
-        protected readonly ILogger logger;
+        private readonly ILogger logger;
         private readonly ISet<string> sourceFiles;
         private readonly ISet<string> referencedJars;
         private readonly ISet<string> extensionClasses;
@@ -244,7 +244,7 @@ namespace SonarQube.Plugins
 
         #region Protected methods
 
-        private ILogger Logger { get { return this.logger; } }
+        protected ILogger Logger { get { return this.logger; } }
 
         protected void SetSourceFileReplacement(string key, string value)
         {

--- a/PluginGenerator/Program.cs
+++ b/PluginGenerator/Program.cs
@@ -42,9 +42,12 @@ namespace SonarQube.Plugins.PluginGenerator
             //TODO: support multiple languages
             string language = "cs";
 
-            PluginBuilder builder = new PluginBuilder(logger);
-            RulesPluginBuilder.ConfigureBuilder(builder, defn, language, rulesFilePath, sqaleFilePath);
-            builder.SetJarFilePath(fullNewJarFilePath);
+            RulesPluginBuilder builder = new RulesPluginBuilder(logger);
+            builder.SetLanguage(language)
+                .SetRulesFilePath(rulesFilePath)
+                .SetSqaleFilePath(sqaleFilePath)
+                .SetProperties(defn)
+                .SetJarFilePath(fullNewJarFilePath);
             builder.Build();
 
             return SUCCESS_CODE;

--- a/PluginGenerator/UIResources.Designer.cs
+++ b/PluginGenerator/UIResources.Designer.cs
@@ -82,65 +82,38 @@ namespace SonarQube.Plugins {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to At least one extension class must be specified.
+        ///   Looks up a localized string similar to The file path for the jar file to be created must be specified.
         /// </summary>
-        internal static string CoreBuilder_MustSpecifyAnExtensionClass {
+        internal static string CoreBuilder_Error_OutputJarPathMustBeSpecified {
             get {
-                return ResourceManager.GetString("CoreBuilder_MustSpecifyAnExtensionClass", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The plugin key must be specified.
-        /// </summary>
-        internal static string CoreBuilder_PluginKeyIsRequired {
-            get {
-                return ResourceManager.GetString("CoreBuilder_PluginKeyIsRequired", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The plugin name must be specified.
-        /// </summary>
-        internal static string CoreBuilder_PluginNameIsRequired {
-            get {
-                return ResourceManager.GetString("CoreBuilder_PluginNameIsRequired", resourceCulture);
+                return ResourceManager.GetString("CoreBuilder_Error_OutputJarPathMustBeSpecified", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to Required plugin definition property is missing: {0}.
         /// </summary>
-        internal static string Error_MissingProperty {
+        internal static string CoreBuilder_Error_RequiredPropertyMissing {
             get {
-                return ResourceManager.GetString("Error_MissingProperty", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The specified rules file does not exist: {0}.
-        /// </summary>
-        internal static string Gen_Error_RulesFileDoesNotExists {
-            get {
-                return ResourceManager.GetString("Gen_Error_RulesFileDoesNotExists", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to The specified sqale file does not exist: {0}.
-        /// </summary>
-        internal static string Gen_Error_SqaleFileDoesNotExists {
-            get {
-                return ResourceManager.GetString("Gen_Error_SqaleFileDoesNotExists", resourceCulture);
+                return ResourceManager.GetString("CoreBuilder_Error_RequiredPropertyMissing", resourceCulture);
             }
         }
         
         /// <summary>
         ///   Looks up a localized string similar to The existing jar file will be overwritten.
         /// </summary>
-        internal static string Gen_ExistingJarWillBeOvewritten {
+        internal static string CoreBuilder_ExistingJarWillBeOvewritten {
             get {
-                return ResourceManager.GetString("Gen_ExistingJarWillBeOvewritten", resourceCulture);
+                return ResourceManager.GetString("CoreBuilder_ExistingJarWillBeOvewritten", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to At least one extension class must be specified.
+        /// </summary>
+        internal static string CoreBuilder_MustSpecifyAnExtensionClass {
+            get {
+                return ResourceManager.GetString("CoreBuilder_MustSpecifyAnExtensionClass", resourceCulture);
             }
         }
         
@@ -222,6 +195,42 @@ namespace SonarQube.Plugins {
         internal static string JComp_SourceCompilationSucceeded {
             get {
                 return ResourceManager.GetString("JComp_SourceCompilationSucceeded", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The rule language must be specified.
+        /// </summary>
+        internal static string RulesBuilder_Error_RuleLanguageMustBeSpecified {
+            get {
+                return ResourceManager.GetString("RulesBuilder_Error_RuleLanguageMustBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified rules file does not exist: {0}.
+        /// </summary>
+        internal static string RulesBuilder_Error_RulesFileDoesNotExists {
+            get {
+                return ResourceManager.GetString("RulesBuilder_Error_RulesFileDoesNotExists", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The path to the rules file must be specified.
+        /// </summary>
+        internal static string RulesBuilder_Error_RulesFileMustBeSpecified {
+            get {
+                return ResourceManager.GetString("RulesBuilder_Error_RulesFileMustBeSpecified", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified sqale file does not exist: {0}.
+        /// </summary>
+        internal static string RulesBuilder_Error_SqaleFileDoesNotExists {
+            get {
+                return ResourceManager.GetString("RulesBuilder_Error_SqaleFileDoesNotExists", resourceCulture);
             }
         }
     }

--- a/PluginGenerator/UIResources.resx
+++ b/PluginGenerator/UIResources.resx
@@ -141,7 +141,7 @@
   <data name="JarB_JDK_NotInstalled" xml:space="preserve">
     <value>The JDK is not installed or is not discoverable on this machine</value>
   </data>
-  <data name="Error_MissingProperty" xml:space="preserve">
+  <data name="CoreBuilder_Error_RequiredPropertyMissing" xml:space="preserve">
     <value>Required plugin definition property is missing: {0}</value>
   </data>
   <data name="JComp_SourceCompilationFailed" xml:space="preserve">
@@ -153,25 +153,28 @@
   <data name="JComp_CompliationFailed" xml:space="preserve">
     <value>Java compilation failed</value>
   </data>
-  <data name="Gen_Error_RulesFileDoesNotExists" xml:space="preserve">
+  <data name="RulesBuilder_Error_RulesFileDoesNotExists" xml:space="preserve">
     <value>The specified rules file does not exist: {0}</value>
   </data>
   <data name="AssemblyDescription" xml:space="preserve">
     <value>Rules Plugin Generator for SonarQube</value>
   </data>
-  <data name="Gen_ExistingJarWillBeOvewritten" xml:space="preserve">
+  <data name="CoreBuilder_ExistingJarWillBeOvewritten" xml:space="preserve">
     <value>The existing jar file will be overwritten</value>
   </data>
   <data name="CoreBuilder_MustSpecifyAnExtensionClass" xml:space="preserve">
     <value>At least one extension class must be specified</value>
   </data>
-  <data name="CoreBuilder_PluginKeyIsRequired" xml:space="preserve">
-    <value>The plugin key must be specified</value>
-  </data>
-  <data name="CoreBuilder_PluginNameIsRequired" xml:space="preserve">
-    <value>The plugin name must be specified</value>
-  </data>
-  <data name="Gen_Error_SqaleFileDoesNotExists" xml:space="preserve">
+  <data name="RulesBuilder_Error_SqaleFileDoesNotExists" xml:space="preserve">
     <value>The specified sqale file does not exist: {0}</value>
+  </data>
+  <data name="CoreBuilder_Error_OutputJarPathMustBeSpecified" xml:space="preserve">
+    <value>The file path for the jar file to be created must be specified</value>
+  </data>
+  <data name="RulesBuilder_Error_RuleLanguageMustBeSpecified" xml:space="preserve">
+    <value>The rule language must be specified</value>
+  </data>
+  <data name="RulesBuilder_Error_RulesFileMustBeSpecified" xml:space="preserve">
+    <value>The path to the rules file must be specified</value>
   </data>
 </root>

--- a/Tests/PluginGeneratorTests/JarChecker.cs
+++ b/Tests/PluginGeneratorTests/JarChecker.cs
@@ -5,19 +5,20 @@
 // </copyright>
 //-----------------------------------------------------------------------
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using SonarQube.Plugins.Test.Common;
 using System.IO;
 using System.IO.Compression;
-using System.Linq;
-using SonarQube.Plugins.Test.Common;
 
 namespace SonarQube.Plugins.PluginGeneratorTests
 {
     internal class JarChecker
     {
         private readonly string unzippedDir;
+        private readonly TestContext testContext;
 
         public JarChecker(TestContext testContext, string fullJarPath)
         {
+            this.testContext = testContext;
             TestUtils.AssertFileExists(fullJarPath);
 
             this.unzippedDir = TestUtils.CreateTestDirectory(testContext, "unzipped");
@@ -28,12 +29,14 @@ namespace SonarQube.Plugins.PluginGeneratorTests
         {
             foreach (string relativePath in expectedRelativePaths)
             {
+                this.testContext.WriteLine("JarChecker: checking for file '{0}'", relativePath);
+
                 string[] matchingFiles = Directory.GetFiles(this.unzippedDir, relativePath, SearchOption.TopDirectoryOnly);
 
                 Assert.IsTrue(matchingFiles.Length < 2, "Test error: supplied relative path should not match multiple files");
-                string fullFilePath = matchingFiles.FirstOrDefault();
+                Assert.AreEqual(1, matchingFiles.Length, "Jar does not contain expected file: {0}", relativePath);
 
-                Assert.IsTrue(File.Exists(fullFilePath), "Jar does not contain expected file: {0}", relativePath);
+                this.testContext.WriteLine("JarChecker: found at '{0}'", matchingFiles[0]);
             }
         }
 

--- a/Tests/PluginGeneratorTests/RulesPluginBuilderTests.cs
+++ b/Tests/PluginGeneratorTests/RulesPluginBuilderTests.cs
@@ -1,5 +1,5 @@
 //-----------------------------------------------------------------------
-// <copyright file="RulesPluginGeneratorTests.cs" company="SonarSource SA and Microsoft Corporation">
+// <copyright file="RulesPluginBuilderTests.cs" company="SonarSource SA and Microsoft Corporation">
 //   Copyright (c) SonarSource SA and Microsoft Corporation.  All rights reserved.
 //   Licensed under the MIT License. See License.txt in the project root for license information.
 // </copyright>
@@ -11,12 +11,12 @@ using System.IO;
 namespace SonarQube.Plugins.PluginGeneratorTests
 {
     [TestClass]
-    public class RulesPluginGeneratorTests
+    public class RulesPluginBuilderTests
     {
         public TestContext TestContext { get; set; }
 
         [TestMethod]
-        public void RulePluginGen_Simple()
+        public void RulesPluginBuilder_CreateSimplePlugin_Succeeds()
         {
             string inputDir = TestUtils.CreateTestDirectory(this.TestContext, "input");
             string outputDir = TestUtils.CreateTestDirectory(this.TestContext, "output");
@@ -24,10 +24,9 @@ namespace SonarQube.Plugins.PluginGeneratorTests
 
             string language = "xx";
             string rulesXmlFilePath = TestUtils.CreateTextFile("rules.xml", inputDir, "<xml Rules />");
+            string sqaleXmlFilePath = TestUtils.CreateTextFile("sqale.xml", inputDir, "<xml sqale />");
 
             IJdkWrapper jdkWrapper = new JdkWrapper();
-            RulesPluginBuilder generator = new RulesPluginBuilder(jdkWrapper, new TestLogger());
-
             PluginManifest defn = new PluginManifest()
             {
                 Key = "MyPlugin",
@@ -39,7 +38,14 @@ namespace SonarQube.Plugins.PluginGeneratorTests
                 Developers = typeof(RulesPluginBuilder).FullName
             };
 
-            generator.GeneratePlugin(defn, language, rulesXmlFilePath, fullJarFilePath);
+            RulesPluginBuilder builder = new RulesPluginBuilder(jdkWrapper, new TestLogger());
+            builder.SetLanguage(language)
+                .SetRulesFilePath(rulesXmlFilePath)
+                .SetSqaleFilePath(sqaleXmlFilePath)
+                .SetJarFilePath(fullJarFilePath)
+                .SetProperties(defn);
+            builder.Build();
+
             if (File.Exists(fullJarFilePath))
             {
                 this.TestContext.AddResultFile(fullJarFilePath);
@@ -48,6 +54,7 @@ namespace SonarQube.Plugins.PluginGeneratorTests
             new JarChecker(this.TestContext, fullJarFilePath)
                 .JarContainsFiles(
                     "resources\\*rules.xml",
+                    "resources\\*sqale.xml",
                     "org\\sonarqube\\plugin\\sdk\\MyPlugin\\Plugin.class",
                     "org\\sonarqube\\plugin\\sdk\\MyPlugin\\PluginRulesDefinition.class");
         }

--- a/Tests/PluginGeneratorTests/SonarQube.Plugins.PluginGeneratorTests.csproj
+++ b/Tests/PluginGeneratorTests/SonarQube.Plugins.PluginGeneratorTests.csproj
@@ -114,7 +114,7 @@
     <Compile Include="NuGetDataModelTests.cs" />
     <Compile Include="PluginBuilderTests.cs" />
     <Compile Include="PluginDefinitionTests.cs" />
-    <Compile Include="RulesPluginGeneratorTests.cs" />
+    <Compile Include="RulesPluginBuilderTests.cs" />
     <Compile Include="SourceGeneratorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>


### PR DESCRIPTION
The RulesPluginBuilder now inherits from PluginBuilder which simplifies the API; the static configuration methods are no longer required.

This refactoring is a pre-cursor to removing the embedded jars from the product code.