### PR TITLE
Add capability to import SQALE templates for each library within an Analyzer package which aggregates other packages.

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,9 @@ The SDK will look for NuGet.config files in the following locations:
 
 If the analyzer you want to package is available in a private NuGet feed then you will need to create an appropriate NuGet.config file to point to the private feed.
 
+#### Generating plugins for aggregating packages
+Some NuGet packages exist to associate several related packages together. To simplify the process of creating plugins for such aggregating packages, the */recurse* flag can be used e.g. *RoslynSonarQubeGenerator CodeCracker /recurse*. The tool will search the dependencies of the given package and create plugins for any dependencies that contain Roslyn analyzers.
+
 #### Generating a jar for an analyzer that is not available from a NuGet feed
 If you want to create a jar for Roslyn analyzer that is not available from a NuGet feed (e.g. an analyzer you have created on your local machine) you can specify a package source that points at a local directory containing the *.nupkg* file created by the standard Roslyn templates. See the [NuGet docs](https://docs.nuget.org/create/hosting-your-own-nuget-feeds) for more information.
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ The generator will create a template SQALE file that contains placeholders for t
 *{package id}.{package version}.sqale.template.xml*.
 
 If you want to provide SQALE information in the generated plugin, you can copy and manually edit the template file to contain the appropriate remediation information. Then generate the plugin again, this time specifying the */sqale:{filename}* option to tell the generator to embed the SQALE file in the plugin.
+If you are working with an aggregating package (see below), you may specify a directory path to your modified template SQALE files within this option (*/sqale:folder).  The appropriate template file will be imported into in each plugin as it is generated. 
 
 See the [SonarQube documentation](http://docs.sonarqube.org/x/_yBq) for more information about how SonarQube uses the SQALE method.
 

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -185,6 +185,11 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     sqaleFilePath = arg.Value;
                     this.logger.LogDebug(CmdLineResources.DEBUG_UsingSqaleFile, sqaleFilePath);
                 }
+                else if (Directory.Exists(arg.Value))
+                {
+                    sqaleFilePath = arg.Value;
+                    this.logger.LogDebug(CmdLineResources.DEBUG_UsingSqalePath, sqaleFilePath);
+                }
                 else
                 {
                     sucess = false;

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -115,6 +115,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Using SQALE files in path &apos;{0}&apos;.
+        /// </summary>
+        internal static string DEBUG_UsingSqalePath {
+            get {
+                return ResourceManager.GetString("DEBUG_UsingSqalePath", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Invalid NuGet package version: {0}.
         /// </summary>
         internal static string ERROR_InvalidVersion {

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -135,6 +135,9 @@
   <data name="DEBUG_UsingSqaleFile" xml:space="preserve">
     <value>Using SQALE file '{0}'</value>
   </data>
+  <data name="DEBUG_UsingSqalePath" xml:space="preserve">
+    <value>Using SQALE files in path '{0}'</value>
+  </data>
   <data name="ERROR_InvalidVersion" xml:space="preserve">
     <value>Invalid NuGet package version: {0}</value>
   </data>


### PR DESCRIPTION
I noticed that there was a branch (sam_dev) which contained an explanation of an unsupported feature that I wanted to leverage (adding SQALE templates into aggregating packages). I took the liberty to write it up, so i figured i'd share it. Hope it's useful.  Let me know if there's anything you want done to tidy up.
