### PR TITLE
Support specifying rule type and adding tags

### DIFF
--- a/PluginGenerator/DataModel/Rule.cs
+++ b/PluginGenerator/DataModel/Rule.cs
@@ -71,7 +71,10 @@ namespace SonarQube.Plugins.Roslyn
 
         [XmlElement(ElementName = "status")]
         public string Status { get; set; }
-        
+
+        [XmlElement(ElementName = "type")]
+        public string Type { get; set; }
+
         [XmlElement(ElementName = "tag")]
         public string[] Tags { get; set; }
 

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -41,6 +41,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             public const string SqaleXmlFile = "sqale.xml";
             public const string AcceptLicenses = "accept.licenses";
             public const string RecurseDependencies = "recurse.dependencies";
+            public const string AddTag = "add.tag";
+            public const string RuleType = "rule.type";
         }
 
         private static IList<ArgumentDescriptor> Descriptors;
@@ -59,6 +61,10 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 id: KeywordIds.AcceptLicenses, prefixes: new string[] { "/acceptLicenses" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_AcceptLicenses, isVerb: true));
             Descriptors.Add(new ArgumentDescriptor(
                 id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true));
+            Descriptors.Add(new ArgumentDescriptor(
+                id: KeywordIds.AddTag, prefixes: new string[] { "/addTag:" }, required: false, allowMultiple: true, description: CmdLineResources.ArgDescription_AddTag));
+            Descriptors.Add(new ArgumentDescriptor(
+                id: KeywordIds.RuleType, prefixes: new string[] { "/ruleType:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RuleType));
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
             Debug.Assert(Descriptors.Select(d => d.Id).Distinct().Count() == Descriptors.Count, "All descriptors must have a unique id");
@@ -121,6 +127,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 
             bool acceptLicense = GetLicenseAcceptance(arguments);
             bool recurseDependencies = GetRecursion(arguments);
+            string[] tagsToAdd = GetTagsToAdd(arguments);
+            string ruleType = GetRuleType(arguments);
 
             if (parsedOk)
             {
@@ -132,7 +140,9 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     sqaleFilePath,
                     acceptLicense,
                     recurseDependencies,
-                    System.IO.Directory.GetCurrentDirectory());
+                    System.IO.Directory.GetCurrentDirectory(),
+                    tagsToAdd,
+                    ruleType);
             }
 
             return processed;
@@ -220,5 +230,17 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             return arg != null;
         }
 
+        private static string[] GetTagsToAdd(IEnumerable<ArgumentInstance> arguments)
+        {
+            ArgumentInstance[] args = arguments.Where(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.AddTag, a.Descriptor.Id)).ToArray();
+            string[] tags = args.Select(x => x.Value).ToArray();
+            return tags;
+        }
+
+        private static string GetRuleType(IEnumerable<ArgumentInstance> arguments)
+        {
+            ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.RuleType, a.Descriptor.Id));
+            return arg == null ? null : arg.Value;
+        }
     }
 }

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CmdLineResources {
@@ -70,6 +70,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /addTag:[tag] - add this tag to all rules .
+        /// </summary>
+        internal static string ArgDescription_AddTag {
+            get {
+                return ResourceManager.GetString("ArgDescription_AddTag", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /a:[NuGet package id]  or  /a:[NuGet package id]:[version].
         /// </summary>
         internal static string ArgDescription_AnalzyerRef {
@@ -84,6 +93,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         internal static string ArgDescription_RecurseDependencies {
             get {
                 return ResourceManager.GetString("ArgDescription_RecurseDependencies", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /ruleType:[&quot;CODE_SMELL&quot; (default) or &quot;BUG&quot; or &quot;VULNERABILITY&quot;] - set all rule&apos;s type to Code smell or Bug or Vulnerabilty.
+        /// </summary>
+        internal static string ArgDescription_RuleType {
+            get {
+                return ResourceManager.GetString("ArgDescription_RuleType", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -120,11 +120,17 @@
   <data name="ArgDescription_AcceptLicenses" xml:space="preserve">
     <value>/acceptLicenses - indicates that you accept the licenses for any packages that required license acceptance</value>
   </data>
+  <data name="ArgDescription_AddTag" xml:space="preserve">
+    <value>/addTag:[tag] - add this tag to all rules </value>
+  </data>
   <data name="ArgDescription_AnalzyerRef" xml:space="preserve">
     <value>/a:[NuGet package id]  or  /a:[NuGet package id]:[version]</value>
   </data>
   <data name="ArgDescription_RecurseDependencies" xml:space="preserve">
     <value>/recurse - search for analyzers in target package and any dependencies</value>
+  </data>
+  <data name="ArgDescription_RuleType" xml:space="preserve">
+    <value>/ruleType:["CODE_SMELL" (default) or "BUG" or "VULNERABILITY"] - set all rule's type to Code smell or Bug or Vulnerabilty</value>
   </data>
   <data name="ArgDescription_SqaleXmlFile" xml:space="preserve">
     <value>/s:[path to sqale xml file]</value>

--- a/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
+++ b/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
@@ -32,8 +32,10 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         private readonly bool acceptLicenses;
         private readonly bool recurseDependencies;
         private readonly string outputDirectory;
+        private readonly string[] tagsToAdd;
+        private readonly string ruleType;
 
-        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, bool acceptLicenses, bool recurseDependencies, string outputDirectory)
+        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, bool acceptLicenses, bool recurseDependencies, string outputDirectory, string[] tagsToAdd, string ruleType)
         {
             if (string.IsNullOrWhiteSpace(packageId))
             {
@@ -53,6 +55,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             this.acceptLicenses = acceptLicenses;
             this.recurseDependencies = recurseDependencies;
             this.outputDirectory = outputDirectory;
+            this.tagsToAdd = tagsToAdd;
+            this.ruleType = ruleType;
         }
 
         public string PackageId { get { return this.packageId; } }
@@ -68,5 +72,9 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         public bool RecurseDependencies { get { return this.recurseDependencies; } }
 
         public string OutputDirectory { get { return this.outputDirectory; } }
+
+        public string[] TagsToAdd { get { return this.tagsToAdd; } }
+
+        public string RuleType { get { return this.ruleType; } }
     }
 }

--- a/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
+++ b/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
@@ -57,7 +57,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir);
+            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir, new string[0], null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -92,7 +92,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false, 
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, new string[0], null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -127,7 +127,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false,
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, new string[0], null);
             bool result = apg.Generate(args);
 
             // Assert

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -626,7 +626,9 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 sqaleFilePath,
                 acceptLicenses,
                 recurseDependencies,
-                outputDirectory);
+                outputDirectory,
+                new string[0],
+                null);
             return args;
         }
         


### PR DESCRIPTION
Adds two command line parameters:
 - "/addTag:<tag>" which adds the `<tag>` to all rules
 - "/ruleType:CODE_SMELL|VULNERABILITY|BUG" allows to set all rules' type to other than the default code smell

Please note this is a preliminary PR which does not includes eg. tests for the new functionality and may violate some Sonar rules (eg. allowed parameter count in a method signature), so let's discuss first what requirements needs to be satisfied before going forward.