### PR TITLE
Fixed #79: used ZipArchive to update jar file

### DIFF
--- a/RoslynPluginGenerator/ArchiveUpdater.cs
+++ b/RoslynPluginGenerator/ArchiveUpdater.cs
@@ -31,7 +31,6 @@ namespace SonarQube.Plugins.Roslyn
     /// </summary>
     public class ArchiveUpdater
     {
-        private readonly string workingDirectory;
         private readonly IDictionary<string, string> fileMap;
         private readonly ILogger logger;
 
@@ -40,15 +39,9 @@ namespace SonarQube.Plugins.Roslyn
 
         #region Public methods
 
-        public ArchiveUpdater(string workingDirectory, ILogger logger)
+        public ArchiveUpdater(ILogger logger)
         {
-            if (string.IsNullOrWhiteSpace(workingDirectory))
-            {
-                throw new ArgumentNullException(nameof(workingDirectory));
-            }
-
             this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
-            this.workingDirectory = workingDirectory;
 
             fileMap = new Dictionary<string, string>();
         }

--- a/RoslynPluginGenerator/ArchiveUpdater.cs
+++ b/RoslynPluginGenerator/ArchiveUpdater.cs
@@ -44,25 +44,22 @@ namespace SonarQube.Plugins.Roslyn
         {
             if (string.IsNullOrWhiteSpace(workingDirectory))
             {
-                throw new ArgumentNullException("workingDirectory");
+                throw new ArgumentNullException(nameof(workingDirectory));
             }
-            if (logger == null)
-            {
-                throw new ArgumentNullException("logger");
-            }
-            this.logger = logger;
+
+            this.logger = logger ?? throw new ArgumentNullException(nameof(logger));
             this.workingDirectory = workingDirectory;
 
-            this.fileMap = new Dictionary<string, string>();
+            fileMap = new Dictionary<string, string>();
         }
 
         public ArchiveUpdater SetInputArchive(string filePath)
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {
-                throw new ArgumentNullException("filePath");
+                throw new ArgumentNullException(nameof(filePath));
             }
-            this.inputArchiveFilePath = filePath;
+            inputArchiveFilePath = filePath;
             return this;
         }
 
@@ -70,107 +67,68 @@ namespace SonarQube.Plugins.Roslyn
         {
             if (string.IsNullOrWhiteSpace(filePath))
             {
-                throw new ArgumentNullException("filePath");
+                throw new ArgumentNullException(nameof(filePath));
             }
-            this.outputArchiveFilePath = filePath;
+            outputArchiveFilePath = filePath;
             return this;
         }
 
         public ArchiveUpdater AddFile(string sourceFilePath, string relativeTargetFilePath)
         {
-            this.fileMap[relativeTargetFilePath] = sourceFilePath;
+            fileMap[relativeTargetFilePath] = sourceFilePath;
             return this;
         }
 
         public void UpdateArchive()
         {
-            this.logger.LogDebug(UIResources.ZIP_UpdatingArchive, this.inputArchiveFilePath);
-
-            string unpackedDir = Utilities.CreateSubDirectory(this.workingDirectory, "unpacked");
-            this.logger.LogDebug(UIResources.ZIP_WorkingDirectory, workingDirectory);
-
-            ZipFile.ExtractToDirectory(this.inputArchiveFilePath, unpackedDir);
-
-            // Add in the new files
-            foreach (KeyValuePair<string, string> kvp in this.fileMap)
+            if (File.Exists(outputArchiveFilePath))
             {
-                this.logger.LogDebug(UIResources.ZIP_InsertingFile, kvp.Key, kvp.Value);
-
-                string targetFilePath = Path.Combine(unpackedDir, kvp.Key);
-                Directory.CreateDirectory(Path.GetDirectoryName(targetFilePath));
-                File.Copy(kvp.Value, targetFilePath);
+                logger.LogDebug(UIResources.ZIP_DeletingExistingJar);
+                File.Delete(outputArchiveFilePath);
             }
+            File.Copy(inputArchiveFilePath, outputArchiveFilePath);
 
-            // Re-zip
-            if (File.Exists(this.outputArchiveFilePath))
-            {
-                this.logger.LogDebug(UIResources.ZIP_DeletingExistingArchive);
-                File.Delete(this.outputArchiveFilePath);
-            }
-
-            ZipUsingShell(unpackedDir, this.outputArchiveFilePath);
-
-            this.logger.LogDebug(UIResources.ZIP_NewArchiveCreated, this.outputArchiveFilePath);
+            logger.LogDebug(UIResources.ZIP_UpdatingJar, inputArchiveFilePath);
+            DoUpdate();
+            logger.LogDebug(UIResources.ZIP_JarUpdated, outputArchiveFilePath);
         }
 
-        /// <summary>
-        /// Zips the folder using the shell
-        /// </summary>
-        /// <remarks>Re-zipping a jar file using the .Net ZipFile class creates an invalid jar
-        /// so we zip using the shell instead.
-        /// The code is doing effectively the same as the PowerShell script used by the 
-        /// packaging project in the SonarQube Scanner for MSBuild:
-        /// See https://github.com/SonarSource-VisualStudio/sonar-msbuild-runner/blob/master/PackagingProjects/CSharpPluginPayload/RepackageCSharpPlugin.ps1
-        /// </remarks>
-        private static void ZipUsingShell(string sourceDir, string targetZipFilePath)
+        private void DoUpdate()
         {
-            // The Folder.CopyHere method for Shell Objects allows configuration based on a combination of flags.
-            // Docs here: https://msdn.microsoft.com/en-us/library/windows/desktop/bb787866(v=vs.85).aspx
-            // The value below (1556) consists of
-            //    (4)    - no progress dialog
-            //    (16)   - respond with "yes to all" to any dialog box
-            //    (512)  - Do not confirm the creation of a new directory
-            //    (1024) - Do not display an UI in case of error
-            const int copyFlags = 1556;
-
-            const int copyPauseInMilliseconds = 500;
-
-            // The file must have a ".zip" extension for the shell code below to work
-            string zipFilePath = targetZipFilePath + ".zip";
-            CreateEmptyZipFile(zipFilePath);
-
-            Type shellAppType = Type.GetTypeFromProgID("Shell.Application");
-            Object app = Activator.CreateInstance(shellAppType);
-
-            Shell32.Folder folder = shellAppType.InvokeMember("NameSpace", System.Reflection.BindingFlags.InvokeMethod, null, app, new object[] { zipFilePath }) as Shell32.Folder;
-
-            foreach(string dir in Directory.GetDirectories(sourceDir))
+            using (ZipArchive newArchive = new ZipArchive(new FileStream(outputArchiveFilePath, FileMode.Open), ZipArchiveMode.Update))
             {
-                folder.CopyHere(dir, copyFlags);
-                System.Threading.Thread.Sleep(copyPauseInMilliseconds);
-            }
-            
-            foreach (string file in Directory.GetFiles(sourceDir, "*.*", SearchOption.TopDirectoryOnly))
-            {
-                folder.CopyHere(file, copyFlags);
-                System.Threading.Thread.Sleep(copyPauseInMilliseconds);
-            }
+                // Add/update the new files
+                foreach (KeyValuePair<string, string> kvp in fileMap)
+                {
+                    var data = File.ReadAllBytes(kvp.Value);
 
-            // Rename the file to the expected name
-            File.Move(zipFilePath, targetZipFilePath);
+                    string canonicalKey = kvp.Key.Replace("\\", "/");
+                    var entry = GetOrCreateEntry(newArchive, canonicalKey);
+
+                    logger.LogDebug(UIResources.ZIP_InsertingFile, kvp.Key, kvp.Value);
+                    using (var entryStream = entry.Open())
+                    {
+                        entryStream.Write(data, 0, data.Length);
+                        entryStream.Flush();
+                    }
+                }
+            }
         }
 
-        private static void CreateEmptyZipFile(string filePath)
+        private ZipArchiveEntry GetOrCreateEntry(ZipArchive archive, string fullEntryName)
         {
-            byte[] emptyZipHeader = new byte[] { 80, 75, 5, 6, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 };
-
-            using (FileStream fs = File.Create(filePath))
+            var existingEntry = archive.GetEntry(fullEntryName);
+            if (existingEntry != null)
             {
-                fs.Write(emptyZipHeader, 0, emptyZipHeader.Length);
-                fs.Flush();
+                logger.LogDebug(UIResources.ZIP_DeleteExistingEntry, fullEntryName);
+                existingEntry.Delete();
             }
-        }
 
-        #endregion
+            logger.LogDebug(UIResources.ZIP_CreatingNewEntry, fullEntryName);
+            return archive.CreateEntry(fullEntryName);
+
+        }
+        
+        #endregion Public methods
     }
 }

--- a/RoslynPluginGenerator/RoslynPluginJarBuilder.cs
+++ b/RoslynPluginGenerator/RoslynPluginJarBuilder.cs
@@ -22,7 +22,6 @@ using SonarQube.Plugins.Common;
 using System;
 using System.Collections.Generic;
 using System.IO;
-using System.Text;
 
 namespace SonarQube.Plugins.Roslyn
 {
@@ -256,7 +255,7 @@ namespace SonarQube.Plugins.Roslyn
 
             // Update the jar
             string templateJarFilePath = ExtractTemplateJarFile(workingDirectory);
-            ArchiveUpdater updater = new ArchiveUpdater(workingDirectory, this.logger);
+            ArchiveUpdater updater = new ArchiveUpdater(this.logger);
 
             updater.SetInputArchive(templateJarFilePath)
                 .SetOutputArchive(this.outputJarFilePath)

--- a/RoslynPluginGenerator/UIResources.Designer.cs
+++ b/RoslynPluginGenerator/UIResources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarQube.Plugins.Roslyn {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     public class UIResources {
@@ -538,16 +538,34 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Deleting existing archive....
+        ///   Looks up a localized string similar to Creating new entry: &apos;{0}&apos;.
         /// </summary>
-        public static string ZIP_DeletingExistingArchive {
+        public static string ZIP_CreatingNewEntry {
             get {
-                return ResourceManager.GetString("ZIP_DeletingExistingArchive", resourceCulture);
+                return ResourceManager.GetString("ZIP_CreatingNewEntry", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Inserting file {0}. Source: {1}.
+        ///   Looks up a localized string similar to Deleting existing entry: &apos;{0}&apos;.
+        /// </summary>
+        public static string ZIP_DeleteExistingEntry {
+            get {
+                return ResourceManager.GetString("ZIP_DeleteExistingEntry", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Deleting existing jar....
+        /// </summary>
+        public static string ZIP_DeletingExistingJar {
+            get {
+                return ResourceManager.GetString("ZIP_DeletingExistingJar", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Inserting file &apos;{0}&apos;. Source: &apos;{1}&apos;.
         /// </summary>
         public static string ZIP_InsertingFile {
             get {
@@ -556,29 +574,20 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to New archive created: {0}.
+        ///   Looks up a localized string similar to Jar updated.
         /// </summary>
-        public static string ZIP_NewArchiveCreated {
+        public static string ZIP_JarUpdated {
             get {
-                return ResourceManager.GetString("ZIP_NewArchiveCreated", resourceCulture);
+                return ResourceManager.GetString("ZIP_JarUpdated", resourceCulture);
             }
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Updating archive {0}.
+        ///   Looks up a localized string similar to Updating jar &apos;{0}&apos;.
         /// </summary>
-        public static string ZIP_UpdatingArchive {
+        public static string ZIP_UpdatingJar {
             get {
-                return ResourceManager.GetString("ZIP_UpdatingArchive", resourceCulture);
-            }
-        }
-        
-        /// <summary>
-        ///   Looks up a localized string similar to Working directory: {0}.
-        /// </summary>
-        public static string ZIP_WorkingDirectory {
-            get {
-                return ResourceManager.GetString("ZIP_WorkingDirectory", resourceCulture);
+                return ResourceManager.GetString("ZIP_UpdatingJar", resourceCulture);
             }
         }
     }

--- a/RoslynPluginGenerator/UIResources.resx
+++ b/RoslynPluginGenerator/UIResources.resx
@@ -282,19 +282,22 @@ Error: {1}</value>
   <data name="Scanner_NoAnalyzers" xml:space="preserve">
     <value>No analyzers found in assembly {0}</value>
   </data>
-  <data name="ZIP_DeletingExistingArchive" xml:space="preserve">
-    <value>Deleting existing archive...</value>
+  <data name="ZIP_CreatingNewEntry" xml:space="preserve">
+    <value>Creating new entry: '{0}'</value>
+  </data>
+  <data name="ZIP_DeleteExistingEntry" xml:space="preserve">
+    <value>Deleting existing entry: '{0}'</value>
+  </data>
+  <data name="ZIP_DeletingExistingJar" xml:space="preserve">
+    <value>Deleting existing jar...</value>
   </data>
   <data name="ZIP_InsertingFile" xml:space="preserve">
-    <value>Inserting file {0}. Source: {1}</value>
+    <value>Inserting file '{0}'. Source: '{1}'</value>
   </data>
-  <data name="ZIP_NewArchiveCreated" xml:space="preserve">
-    <value>New archive created: {0}</value>
+  <data name="ZIP_JarUpdated" xml:space="preserve">
+    <value>Jar updated</value>
   </data>
-  <data name="ZIP_UpdatingArchive" xml:space="preserve">
-    <value>Updating archive {0}</value>
-  </data>
-  <data name="ZIP_WorkingDirectory" xml:space="preserve">
-    <value>Working directory: {0}</value>
+  <data name="ZIP_UpdatingJar" xml:space="preserve">
+    <value>Updating jar '{0}'</value>
   </data>
 </root>

--- a/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
@@ -58,9 +58,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             string addFile1 = TestUtils.CreateTextFile("additional1.txt", rootTestDir, "a1");
             string addFile2 = TestUtils.CreateTextFile("additional2.txt", rootTestDir, "a2");
 
-            string updaterRootDir = TestUtils.CreateTestDirectory(this.TestContext, "updater");
-
-            ArchiveUpdater updater = new ArchiveUpdater(updaterRootDir, new TestLogger());
+            ArchiveUpdater updater = new ArchiveUpdater(new TestLogger());
 
             // Act
             updater.SetInputArchive(originalZipFile)
@@ -106,7 +104,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
 
 
             // Act
-            ArchiveUpdater updater = new ArchiveUpdater(rootTestDir, new TestLogger());
+            ArchiveUpdater updater = new ArchiveUpdater(new TestLogger());
 
             updater.SetInputArchive(originalZipFile)
                 .SetOutputArchive(updatedZipFile)

--- a/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
@@ -85,6 +85,73 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 );
         }
 
+        [TestMethod]
+        public void ExistingEntryUpdated_And_NewEntryAdded()
+        {
+            // Arrange - create an input archive file
+            string rootTestDir = TestUtils.CreateTestDirectory(this.TestContext);
+            string originalZipFile = Path.Combine(rootTestDir, "original.zip");
+            string updatedZipFile = Path.Combine(rootTestDir, "updated.zip");
+
+            using (var archive = new ZipArchive(File.Create(originalZipFile), ZipArchiveMode.Create))
+            {
+                AddEntry(archive, "sub/unchanged", "unchanged value");
+                AddEntry(archive, "sub/changed", "original data in file that is going to be changed to something shorted");
+            }
+
+            Assert.IsTrue(File.Exists(originalZipFile), "Test setup error: original zip file not created");
+
+            string changedFile = TestUtils.CreateTextFile("changed.txt", rootTestDir, "new data in changed file");
+            string newFile = TestUtils.CreateTextFile("newfile.txt", rootTestDir, "new file");
+
+
+            // Act
+            ArchiveUpdater updater = new ArchiveUpdater(rootTestDir, new TestLogger());
+
+            updater.SetInputArchive(originalZipFile)
+                .SetOutputArchive(updatedZipFile)
+                .AddFile(changedFile, "sub/changed")
+                .AddFile(newFile, "newfile");
+            updater.UpdateArchive();
+
+
+            // Assert
+            using (var updatedArchive = new ZipArchive(File.OpenRead(updatedZipFile), ZipArchiveMode.Read))
+            {
+                AssertEntryExists(updatedArchive, "sub/unchanged", "unchanged value");
+                AssertEntryExists(updatedArchive, "sub/changed", "new data in changed file");
+                AssertEntryExists(updatedArchive, "newfile", "new file");
+            }
+        }
+
+        private static void AddEntry(ZipArchive archive, string entryFullName, string text)
+        {
+            var entry = archive.CreateEntry(entryFullName);
+            using (var stream = entry.Open())
+            {   
+                var data = System.Text.Encoding.UTF8.GetBytes(text);
+                stream.Write(data, 0, data.Length);
+            }
+        }
+
+        private static void AssertEntryExists(ZipArchive archive, string entryFullName, string expectedText)
+        {
+            var entry = archive.GetEntry(entryFullName);
+            Assert.IsNotNull(entry, $"Expected entry not found: {entryFullName}");
+
+            const int MAX_DATA_LENGTH = 100;
+
+            using (var stream = entry.Open())
+            {
+                var actualData = new byte[MAX_DATA_LENGTH];
+                var actualLength = stream.Read(actualData, 0, MAX_DATA_LENGTH);
+                Assert.IsTrue(actualLength < MAX_DATA_LENGTH, $"Test setup error: sample test string should be less than {MAX_DATA_LENGTH}");
+
+                var actualText = System.Text.Encoding.UTF8.GetString(actualData, 0, actualLength);
+                Assert.AreEqual(expectedText, actualText, $"Entry does not contain the expected data. Entry: {entryFullName}");
+            }
+        }
+
         #endregion
     }
 }


### PR DESCRIPTION
Stopped using Windows Shell to update the jar file.
The main reason for fixing this issue now is to see if the VSTS _Hosted VS2017_ agent can now successfully build the solution.