### PR TITLE
Fixed #77: upgrade to NuGet 4.7

### DIFF
--- a/Common/SonarQube.Plugins.Common.csproj
+++ b/Common/SonarQube.Plugins.Common.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Common</RootNamespace>
     <AssemblyName>SonarQube.Plugins.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Common/packages.config
+++ b/Common/packages.config
@@ -1,11 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
 </packages>

--- a/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
+++ b/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
@@ -18,7 +18,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins</RootNamespace>
     <AssemblyName>SonarQube.Plugins.PluginGenerator</AssemblyName>
-	  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
+++ b/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
@@ -18,7 +18,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins</RootNamespace>
     <AssemblyName>SonarQube.Plugins.PluginGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+	  <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>

--- a/RoslynPluginGenerator/App.config
+++ b/RoslynPluginGenerator/App.config
@@ -1,45 +1,45 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
   <startup>
-    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+    <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6"/>
   </startup>
   <runtime>
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
-        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.0.21.0" newVersion="1.0.21.0" />
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.0.21.0" newVersion="1.0.21.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.CSharp.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.VisualBasic.Workspaces" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
       <dependentAssembly>
-        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+        <assemblyIdentity name="Microsoft.CodeAnalysis.Workspaces.Desktop" publicKeyToken="31bf3856ad364e35" culture="neutral"/>
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0"/>
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
+++ b/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
@@ -9,7 +9,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Roslyn</RootNamespace>
     <AssemblyName>RoslynSonarQubePluginGenerator</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
@@ -144,7 +144,9 @@
     <Compile Include="ZipExtensions.cs" />
   </ItemGroup>
   <ItemGroup>
-    <None Include="App.config" />
+    <None Include="App.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="NuGet.config">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
+++ b/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
@@ -65,7 +65,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet">
-      <HintPath>..\packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe</HintPath>
+      <HintPath>..\packages\NuGet.CommandLine.4.7.0\tools\NuGet.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/RoslynPluginGenerator/packages.config
+++ b/RoslynPluginGenerator/packages.config
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
 </packages>

--- a/RoslynPluginGenerator/packages.config
+++ b/RoslynPluginGenerator/packages.config
@@ -9,7 +9,7 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="4.7.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
 </packages>

--- a/Tests/Common/SonarQube.Plugins.Test.Common.csproj
+++ b/Tests/Common/SonarQube.Plugins.Test.Common.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Test.Common</RootNamespace>
     <AssemblyName>SonarQube.Plugins.Test.Common</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Tests/Common/SonarQube.Plugins.Test.Common.csproj
+++ b/Tests/Common/SonarQube.Plugins.Test.Common.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Test.Common</RootNamespace>
     <AssemblyName>SonarQube.Plugins.Test.Common</AssemblyName>
-	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">

--- a/Tests/Common/packages.config
+++ b/Tests/Common/packages.config
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/Tests/CommonTests/SonarQube.Plugins.CommonTests.csproj
+++ b/Tests/CommonTests/SonarQube.Plugins.CommonTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.CommonTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.CommonTests</AssemblyName>
-	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Tests/CommonTests/SonarQube.Plugins.CommonTests.csproj
+++ b/Tests/CommonTests/SonarQube.Plugins.CommonTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.CommonTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.CommonTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Tests/CommonTests/packages.config
+++ b/Tests/CommonTests/packages.config
@@ -1,13 +1,13 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/RoslynAnalyzer10.csproj
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/RoslynAnalyzer10.csproj
@@ -52,6 +52,7 @@
     </EmbeddedResource>
   </ItemGroup>
   <ItemGroup>
+    <None Include="app.config" />
     <None Include="Diagnostic.nuspec">
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
@@ -112,19 +113,4 @@
     </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.5\Microsoft.Portable.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
-      <Output TaskParameter="Assemblies" ItemName="AnalyzerAssemblyInfo" />
-    </GetAssemblyIdentity>
-    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe&quot; pack Diagnostic.nuspec -NoPackageAnalysis -Version %(AnalyzerAssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
-    </Exec>
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/RoslynAnalyzer10.csproj
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/RoslynAnalyzer10.csproj
@@ -56,6 +56,7 @@
       <SubType>Designer</SubType>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="packages.config" />
     <None Include="tools\install.ps1">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/app.config
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/app.config
@@ -1,0 +1,15 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<configuration>
+  <runtime>
+    <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
+      <dependentAssembly>
+        <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.37.0" newVersion="1.1.37.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Reflection.Metadata" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.1.0.0" newVersion="1.1.0.0" />
+      </dependentAssembly>
+    </assemblyBinding>
+  </runtime>
+</configuration>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/packages.config
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer10/RoslynAnalyzer10/packages.config
@@ -6,7 +6,6 @@
   <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="portable45-net45+win8" />
 </packages>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer11/RoslynAnalyzer11/RoslynAnalyzer11.csproj
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer11/RoslynAnalyzer11/RoslynAnalyzer11.csproj
@@ -137,19 +137,4 @@
     </AdditionalFiles>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\v4.5\Microsoft.Portable.CSharp.targets" />
-  <Target Name="AfterBuild">
-    <GetAssemblyIdentity AssemblyFiles="$(OutDir)\$(AssemblyName).dll">
-      <Output TaskParameter="Assemblies" ItemName="ExampleAnalyzer1AssemblyInfo" />
-    </GetAssemblyIdentity>
-    <Exec Command="&quot;$(SolutionDir)packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe&quot; pack Diagnostic.nuspec -NoPackageAnalysis -Version %(ExampleAnalyzer1AssemblyInfo.Version) -OutputDirectory ." WorkingDirectory="$(OutDir)" LogStandardErrorAsError="true" ConsoleToMSBuild="true">
-      <Output TaskParameter="ConsoleOutput" PropertyName="OutputOfExec" />
-    </Exec>
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
 </Project>

--- a/Tests/ExampleAnalyzers/RoslynAnalyzer11/RoslynAnalyzer11/packages.config
+++ b/Tests/ExampleAnalyzers/RoslynAnalyzer11/RoslynAnalyzer11/packages.config
@@ -8,7 +8,6 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.1.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.1.0" targetFramework="portable45-net45+win8" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="portable45-net45+win8" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="portable45-net45+win8" />
   <package id="System.Collections.Immutable" version="1.1.37" targetFramework="portable45-net45+win8" />
   <package id="System.Reflection.Metadata" version="1.1.0" targetFramework="portable45-net45+win8" />
 </packages>

--- a/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/Tests/IntegrationTests/IntegrationTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.IntegrationTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.IntegrationTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/Tests/IntegrationTests/IntegrationTests.csproj
+++ b/Tests/IntegrationTests/IntegrationTests.csproj
@@ -68,7 +68,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet">
-      <HintPath>..\..\packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe</HintPath>
+      <HintPath>..\..\packages\NuGet.CommandLine.4.7.0\tools\NuGet.exe</HintPath>
     </Reference>
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.Collections.Immutable.1.1.37\lib\dotnet\System.Collections.Immutable.dll</HintPath>
@@ -150,7 +150,9 @@
     <None Include="..\..\RoslynPluginGenerator\App.config">
       <Link>App.config</Link>
     </None>
-    <None Include="packages.config" />
+    <None Include="packages.config">
+      <SubType>Designer</SubType>
+    </None>
   </ItemGroup>
   <ItemGroup>
     <Analyzer Include="..\..\packages\Microsoft.CodeAnalysis.Analyzers.1.0.0\analyzers\dotnet\cs\Microsoft.CodeAnalysis.Analyzers.dll" />

--- a/Tests/IntegrationTests/packages.config
+++ b/Tests/IntegrationTests/packages.config
@@ -10,6 +10,7 @@
   <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
   <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="4.7.0" targetFramework="net46" />
   <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
   <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />

--- a/Tests/IntegrationTests/packages.config
+++ b/Tests/IntegrationTests/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/Tests/PluginGeneratorTests/SonarQube.Plugins.PluginGeneratorTests.csproj
+++ b/Tests/PluginGeneratorTests/SonarQube.Plugins.PluginGeneratorTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.PluginGeneratorTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.PluginGeneratorTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -139,7 +140,9 @@
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
-    <None Include="app.config" />
+    <None Include="app.config">
+      <SubType>Designer</SubType>
+    </None>
     <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>

--- a/Tests/PluginGeneratorTests/app.config
+++ b/Tests/PluginGeneratorTests/app.config
@@ -12,4 +12,4 @@
       </dependentAssembly>
     </assemblyBinding>
   </runtime>
-</configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6" /></startup></configuration>

--- a/Tests/PluginGeneratorTests/packages.config
+++ b/Tests/PluginGeneratorTests/packages.config
@@ -1,16 +1,16 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net452" />
-  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net452" />
-  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net452" />
-  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Analyzers" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.CSharp.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.VisualBasic.Workspaces" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.CodeAnalysis.Workspaces.Common" version="1.0.0" targetFramework="net46" />
+  <package id="Microsoft.Composition" version="1.0.27" targetFramework="net46" />
+  <package id="System.Collections.Immutable" version="1.1.36" targetFramework="net46" />
+  <package id="System.Reflection.Metadata" version="1.0.21" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.Roslyn.PluginGeneratorTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -67,7 +67,7 @@
       <Private>True</Private>
     </Reference>
     <Reference Include="NuGet">
-      <HintPath>..\..\packages\NuGet.CommandLine.3.3.0\tools\NuGet.exe</HintPath>
+      <HintPath>..\..\packages\NuGet.CommandLine.4.7.0\tools\NuGet.exe</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Collections.Immutable, Version=1.1.37.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests</RootNamespace>
     <AssemblyName>SonarQube.Plugins.Roslyn.PluginGeneratorTests</AssemblyName>
-	<TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.6</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>

--- a/Tests/RoslynPluginGeneratorTests/packages.config
+++ b/Tests/RoslynPluginGeneratorTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="4.7.0" targetFramework="net46" developmentDependency="true" />
   <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>

--- a/Tests/RoslynPluginGeneratorTests/packages.config
+++ b/Tests/RoslynPluginGeneratorTests/packages.config
@@ -1,6 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="FluentAssertions" version="5.4.1" targetFramework="net452" />
-  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net452" />
-  <package id="System.ValueTuple" version="4.4.0" targetFramework="net452" />
+  <package id="FluentAssertions" version="5.4.1" targetFramework="net46" />
+  <package id="NuGet.CommandLine" version="3.3.0" targetFramework="net46" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net46" />
 </packages>


### PR DESCRIPTION
NuGet 4.7 requires Net46 or higher, so I first upgraded the projects to target Net46.

There are no product code changes, just changes to project and package.config files.