### PR TITLE
Fixed #89: allow user to customize rules xml

### DIFF
--- a/PluginGenerator/DataModel/DebtRemediationFunctionType.cs
+++ b/PluginGenerator/DataModel/DebtRemediationFunctionType.cs
@@ -23,8 +23,8 @@ namespace SonarQube.Plugins.Roslyn
     public enum DebtRemediationFunctionType
     {
         Unspecified,
-        LINEAR,
-        LINEAR_OFFSET,
+        LINEAR,             // Currently not supported by the C# plugin (v7.3)
+        LINEAR_OFFSET,      // Currently not supported by the C# plugin (v7.3)
         CONSTANT_ISSUE
     }
 }

--- a/PluginGenerator/DataModel/DebtRemediationFunctionType.cs
+++ b/PluginGenerator/DataModel/DebtRemediationFunctionType.cs
@@ -1,0 +1,30 @@
+﻿/*
+ * SonarQube Roslyn SDK
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+namespace SonarQube.Plugins.Roslyn
+{
+    public enum DebtRemediationFunctionType
+    {
+        Unspecified,
+        LINEAR,
+        LINEAR_OFFSET,
+        CONSTANT_ISSUE
+    }
+}

--- a/PluginGenerator/DataModel/IssueType.cs
+++ b/PluginGenerator/DataModel/IssueType.cs
@@ -1,0 +1,29 @@
+﻿/*
+ * SonarQube Roslyn SDK
+ * Copyright (C) 2015-2017 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+ namespace SonarQube.Plugins.Roslyn
+{
+    public enum IssueType
+    {
+        CODE_SMELL,
+        BUG,
+        VULNERABILITY
+    }
+}

--- a/PluginGenerator/DataModel/Rule.cs
+++ b/PluginGenerator/DataModel/Rule.cs
@@ -74,6 +74,36 @@ namespace SonarQube.Plugins.Roslyn
         [XmlElement(ElementName = "tag")]
         public string[] Tags { get; set; }
 
+        [XmlIgnore]
+        public DebtRemediationFunctionType DebtRemediationFunction { get; set; }
+
+        /// <summary>
+        /// Do not read/write this property directly - use <see cref="DebtRemediationFunction"/> instead.
+        /// </summary>
+        /// <remarks>This property is a hack that allows us to use an enum to specify
+        /// debt remediation function, but to have nothing written to the XML if the
+        /// the value is not specified. There are other ways to do this, but they required
+        /// much more code.</remarks>
+        [XmlElement(ElementName = "debtRemediationFunction")]
+        public string DebtRemediationFunction_DoNotUse_ForSerializationOnly
+        {
+            get
+            {
+                if (DebtRemediationFunction == DebtRemediationFunctionType.Unspecified)
+                {
+                    return null;
+                }
+                return DebtRemediationFunction.ToString();
+            }
+            set
+            {
+                this.DebtRemediationFunction = (DebtRemediationFunctionType)Enum.Parse(typeof(DebtRemediationFunctionType), value);
+            }
+        }
+
+        [XmlElement(ElementName = "debtRemediationFunctionOffset")]
+        public string DebtRemediationFunctionOffset { get; set; }
+
         /// <summary>
         /// Specified the culture and case when comparing rule keys
         /// </summary>

--- a/PluginGenerator/DataModel/Rule.cs
+++ b/PluginGenerator/DataModel/Rule.cs
@@ -68,6 +68,9 @@ namespace SonarQube.Plugins.Roslyn
         [XmlElement(ElementName = "status")]
         public string Status { get; set; }
 
+        [XmlElement(ElementName = "type")]
+        public IssueType Type { get; set; }
+
         [XmlElement(ElementName = "tag")]
         public string[] Tags { get; set; }
 

--- a/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
+++ b/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataModel\IssueType.cs" />
     <Compile Include="DataModel\Rule.cs" />
     <Compile Include="DataModel\Rules.cs" />
     <Compile Include="JarManifestBuilder.cs" />

--- a/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
+++ b/PluginGenerator/SonarQube.Plugins.PluginGenerator.csproj
@@ -52,6 +52,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="DataModel\DebtRemediationFunctionType.cs" />
     <Compile Include="DataModel\IssueType.cs" />
     <Compile Include="DataModel\Rule.cs" />
     <Compile Include="DataModel\Rules.cs" />

--- a/RoslynPluginGenerator/AnalyzerPluginGenerator.cs
+++ b/RoslynPluginGenerator/AnalyzerPluginGenerator.cs
@@ -46,6 +46,11 @@ namespace SonarQube.Plugins.Roslyn
         private static readonly string[] excludedFileExtensions = { ".nupkg", ".nuspec" };
 
         /// <summary>
+        /// Specifies the format for the name of the template rules xml file
+        /// </summary>
+        public const string RulesTemplateFileNameFormat = "{0}.{1}.rules.template.xml";
+
+        /// <summary>
         /// Specifies the format for the name of the placeholder SQALE file
         /// </summary>
         public const string SqaleTemplateFileNameFormat = "{0}.{1}.sqale.template.xml";
@@ -134,7 +139,7 @@ namespace SonarQube.Plugins.Roslyn
             // Initial run with the user-targeted package and arguments
             if (analyzersByPackage.ContainsKey(targetPackage))
             {
-                string generatedJarPath = GeneratePluginForPackage(args.OutputDirectory, args.Language, args.SqaleFilePath, targetPackage, analyzersByPackage[targetPackage]);
+                string generatedJarPath = GeneratePluginForPackage(args.OutputDirectory, args.Language, args.SqaleFilePath, args.RuleFilePath, targetPackage, analyzersByPackage[targetPackage]);
                 if (generatedJarPath == null)
                 {
                     return false;
@@ -147,12 +152,12 @@ namespace SonarQube.Plugins.Roslyn
             // Dependent package generation changes the arguments
             if (args.RecurseDependencies)
             {
-                logger.LogWarning(UIResources.APG_RecurseEnabled_SQALENotEnabled);
+                logger.LogWarning(UIResources.APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled);
 
                 foreach (IPackage currentPackage in analyzersByPackage.Keys)
                 {
-                    // No way to specify the SQALE file for any but the user-targeted package at this time
-                    string generatedJarPath = GeneratePluginForPackage(args.OutputDirectory, args.Language, null, currentPackage, analyzersByPackage[currentPackage]);
+                    // No way to specify the SQALE or rules xml files for any but the user-targeted package at this time
+                    string generatedJarPath = GeneratePluginForPackage(args.OutputDirectory, args.Language, null, null, currentPackage, analyzersByPackage[currentPackage]);
                     if (generatedJarPath == null)
                     {
                         return false;
@@ -172,7 +177,7 @@ namespace SonarQube.Plugins.Roslyn
             return true;
         }
 
-        private string GeneratePluginForPackage(string outputDir, string language, string sqaleFilePath, IPackage package, IEnumerable<DiagnosticAnalyzer> analyzers)
+        private string GeneratePluginForPackage(string outputDir, string language, string sqaleFilePath, string rulesFilePath, IPackage package, IEnumerable<DiagnosticAnalyzer> analyzers)
         {
             Debug.Assert(analyzers.Any(), "The method must be called with a populated list of DiagnosticAnalyzers.");
 
@@ -187,6 +192,7 @@ namespace SonarQube.Plugins.Roslyn
             {
                 Language = language,
                 SqaleFilePath = sqaleFilePath,
+                RulesFilePath = rulesFilePath,
                 PackageId = package.Id,
                 PackageVersion = package.Version.ToString(),
                 Manifest = CreatePluginManifest(package)
@@ -197,10 +203,23 @@ namespace SonarQube.Plugins.Roslyn
             definition.SourceZipFilePath = CreateAnalyzerStaticPayloadFile(packageDir, baseDirectory);
             definition.StaticResourceName = Path.GetFileName(definition.SourceZipFilePath);
 
-            definition.RulesFilePath = GenerateRulesFile(analyzers, baseDirectory);
+            bool generate = true;
+
+            string generatedRulesTemplateFile = null;
+            if (definition.RulesFilePath == null)
+            {
+                definition.RulesFilePath = GenerateRulesFile(analyzers, baseDirectory);
+                generatedRulesTemplateFile = CalculateRulesTemplateFileName(package, outputDir);
+                File.Copy(definition.RulesFilePath, generatedRulesTemplateFile, overwrite: true);
+            }
+            else
+            {
+                this.logger.LogInfo(UIResources.APG_UsingSuppliedRulesFile, definition.RulesFilePath);
+                generate = IsValidRulesFile(definition.RulesFilePath);
+            }
 
             string generatedSqaleFile = null;
-            bool generate = true;
+            
             if (definition.SqaleFilePath == null)
             {
                 generatedSqaleFile = CalculateSqaleFileName(package, outputDir);
@@ -209,6 +228,7 @@ namespace SonarQube.Plugins.Roslyn
             }
             else
             {
+                this.logger.LogInfo(UIResources.APG_UsingSuppliedSqaleFile, definition.SqaleFilePath);
                 generate = IsValidSqaleFile(definition.SqaleFilePath);
             }
 
@@ -217,9 +237,19 @@ namespace SonarQube.Plugins.Roslyn
                 createdJarFilePath = BuildPlugin(definition, outputDir);
             }
 
+            LogMessageForGeneratedRules(generatedRulesTemplateFile);
             LogMessageForGeneratedSqale(generatedSqaleFile);
 
             return createdJarFilePath;
+        }
+
+        private void LogMessageForGeneratedRules(string generatedFile)
+        {
+            if (generatedFile != null)
+            {
+                // Log a message about the generated rules xml file for every plugin generated
+                this.logger.LogInfo(UIResources.APG_TemplateRuleFileGenerated, generatedFile);
+            }
         }
 
         private void LogMessageForGeneratedSqale(string generatedSqaleFile)
@@ -347,6 +377,15 @@ namespace SonarQube.Plugins.Roslyn
             return rulesFilePath;
         }
 
+        private static string CalculateRulesTemplateFileName(IPackage package, string directory)
+        {
+            string filePath = string.Format(System.Globalization.CultureInfo.CurrentCulture,
+                RulesTemplateFileNameFormat, package.Id, package.Version);
+
+            filePath = Path.Combine(directory, filePath);
+            return filePath;
+        }
+
         private static string CalculateSqaleFileName(IPackage package, string directory)
         {
             string filePath = string.Format(System.Globalization.CultureInfo.CurrentCulture,
@@ -369,6 +408,29 @@ namespace SonarQube.Plugins.Roslyn
 
             Serializer.SaveModel(sqale, outputFilePath);
             logger.LogDebug(UIResources.APG_SqaleGeneratedToFile, outputFilePath);
+        }
+
+        /// <summary>
+        /// Checks that the supplied rule file has valid content
+        /// </summary>
+        private bool IsValidRulesFile(string filePath)
+        {
+            Debug.Assert(!string.IsNullOrWhiteSpace(filePath));
+            // Existence is checked when parsing the arguments
+            Debug.Assert(File.Exists(filePath), "Expecting the rule file to exist: " + filePath);
+
+            try
+            {
+                // TODO: consider adding further checks
+                Serializer.LoadModel<Rules>(filePath);
+
+            }
+            catch (InvalidOperationException) // will be thrown for invalid xml
+            {
+                this.logger.LogError(UIResources.APG_InvalidRulesFile, filePath);
+                return false;
+            }
+            return true;
         }
 
         /// <summary>

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -116,8 +116,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 
             parsedOk &= TryParseSqaleFile(arguments, out string sqaleFilePath);
 
-            string ruleFilePath;
-            parsedOk &= TryParseRuleFile(arguments, out ruleFilePath);
+            parsedOk &= TryParseRuleFile(arguments, out string ruleFilePath);
 
             bool acceptLicense = GetLicenseAcceptance(arguments);
             bool recurseDependencies = GetRecursion(arguments);

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -188,46 +188,50 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 
         private bool TryParseSqaleFile(IEnumerable<ArgumentInstance> arguments, out string sqaleFilePath)
         {
-            bool sucess = true;
             sqaleFilePath = null;
             ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.SqaleXmlFile, a.Descriptor.Id));
 
-            if (arg != null)
+            if (arg == null)
             {
-                if (File.Exists(arg.Value))
-                {
-                    sqaleFilePath = arg.Value;
-                    logger.LogDebug(CmdLineResources.DEBUG_UsingSqaleFile, sqaleFilePath);
-                }
-                else
-                {
-                    sucess = false;
-                    logger.LogError(CmdLineResources.ERROR_SqaleFileNotFound, arg.Value);
-                }
+                return true;
             }
-            return sucess;
+
+            bool success = true;
+            if (File.Exists(arg.Value))
+            {
+                sqaleFilePath = arg.Value;
+                logger.LogDebug(CmdLineResources.DEBUG_UsingSqaleFile, sqaleFilePath);
+            }
+            else
+            {
+                success = false;
+                logger.LogError(CmdLineResources.ERROR_SqaleFileNotFound, arg.Value);
+            }
+            return success;
         }
 
         private bool TryParseRuleFile(IEnumerable<ArgumentInstance> arguments, out string ruleFilePath)
         {
-            bool sucess = true;
             ruleFilePath = null;
             ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.RuleXmlFile, a.Descriptor.Id));
 
-            if (arg != null)
+            if (arg == null)
             {
-                if (File.Exists(arg.Value))
-                {
-                    ruleFilePath = arg.Value;
-                    this.logger.LogDebug(CmdLineResources.DEBUG_UsingRuleFile, ruleFilePath);
-                }
-                else
-                {
-                    sucess = false;
-                    this.logger.LogError(CmdLineResources.ERROR_RuleFileNotFound, arg.Value);
-                }
+                return true;
             }
-            return sucess;
+
+            bool success = true;
+            if (File.Exists(arg.Value))
+            {
+                ruleFilePath = arg.Value;
+                this.logger.LogDebug(CmdLineResources.DEBUG_UsingRuleFile, ruleFilePath);
+            }
+            else
+            {
+                success = false;
+                this.logger.LogError(CmdLineResources.ERROR_RuleFileNotFound, arg.Value);
+            }
+            return success;
         }
 
         private static bool GetLicenseAcceptance(IEnumerable<ArgumentInstance> arguments)

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -19,7 +19,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class CmdLineResources {
@@ -88,7 +88,16 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to /s:[path to sqale xml file].
+        ///   Looks up a localized string similar to /rules:[path to rules xml file].
+        /// </summary>
+        internal static string ArgDescription_RuleXmlFile {
+            get {
+                return ResourceManager.GetString("ArgDescription_RuleXmlFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to /sqale:[path to sqale xml file].
         /// </summary>
         internal static string ArgDescription_SqaleXmlFile {
             get {
@@ -102,6 +111,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         internal static string DEBUG_ParsedReference {
             get {
                 return ResourceManager.GetString("DEBUG_ParsedReference", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using rules xml file &apos;{0}&apos;.
+        /// </summary>
+        internal static string DEBUG_UsingRuleFile {
+            get {
+                return ResourceManager.GetString("DEBUG_UsingRuleFile", resourceCulture);
             }
         }
         
@@ -129,6 +147,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         internal static string ERROR_MissingPackageId {
             get {
                 return ResourceManager.GetString("ERROR_MissingPackageId", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to The specified rules xml file could not found: {0}.
+        /// </summary>
+        internal static string ERROR_RuleFileNotFound {
+            get {
+                return ResourceManager.GetString("ERROR_RuleFileNotFound", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -126,11 +126,17 @@
   <data name="ArgDescription_RecurseDependencies" xml:space="preserve">
     <value>/recurse - search for analyzers in target package and any dependencies</value>
   </data>
+  <data name="ArgDescription_RuleXmlFile" xml:space="preserve">
+    <value>/rules:[path to rules xml file]</value>
+  </data>
   <data name="ArgDescription_SqaleXmlFile" xml:space="preserve">
-    <value>/s:[path to sqale xml file]</value>
+    <value>/sqale:[path to sqale xml file]</value>
   </data>
   <data name="DEBUG_ParsedReference" xml:space="preserve">
     <value>Parsed NuGet reference. Id: {0}, version: {1}</value>
+  </data>
+  <data name="DEBUG_UsingRuleFile" xml:space="preserve">
+    <value>Using rules xml file '{0}'</value>
   </data>
   <data name="DEBUG_UsingSqaleFile" xml:space="preserve">
     <value>Using SQALE file '{0}'</value>
@@ -140,6 +146,9 @@
   </data>
   <data name="ERROR_MissingPackageId" xml:space="preserve">
     <value>NuGet package id must be specified</value>
+  </data>
+  <data name="ERROR_RuleFileNotFound" xml:space="preserve">
+    <value>The specified rules xml file could not found: {0}</value>
   </data>
   <data name="ERROR_SqaleFileNotFound" xml:space="preserve">
     <value>The specified SQALE file could not found: {0}</value>

--- a/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
+++ b/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
@@ -25,7 +25,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 {
     public class ProcessedArgs
     {
-        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, bool acceptLicenses, bool recurseDependencies, string outputDirectory)
+        public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string sqaleFilePath, string ruleFilePath,
+            bool acceptLicenses, bool recurseDependencies, string outputDirectory)
         {
             if (string.IsNullOrWhiteSpace(packageId))
             {
@@ -41,6 +42,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             PackageId = packageId;
             PackageVersion = packageVersion;
             SqaleFilePath = sqaleFilePath; // can be null
+            RuleFilePath = ruleFilePath;
             Language = language;
             AcceptLicenses = acceptLicenses;
             RecurseDependencies = recurseDependencies;
@@ -52,6 +54,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         public SemanticVersion PackageVersion { get; }
 
         public string SqaleFilePath { get; }
+
+        public string RuleFilePath { get; }
 
         public string Language { get; }
 

--- a/RoslynPluginGenerator/UIResources.Designer.cs
+++ b/RoslynPluginGenerator/UIResources.Designer.cs
@@ -106,6 +106,15 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to The specified rules xml file is invalid: {0}.
+        /// </summary>
+        public static string APG_InvalidRulesFile {
+            get {
+                return ResourceManager.GetString("APG_InvalidRulesFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to The specified SQALE file is invalid: {0}.
         /// </summary>
         public static string APG_InvalidSqaleFile {
@@ -196,11 +205,11 @@ namespace SonarQube.Plugins.Roslyn {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to SQALE information cannot currently be embedded into plugins generated from package dependencies..
+        ///   Looks up a localized string similar to SQALE and customised rule xml information cannot currently be embedded into plugins generated from package dependencies..
         /// </summary>
-        public static string APG_RecurseEnabled_SQALENotEnabled {
+        public static string APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled {
             get {
-                return ResourceManager.GetString("APG_RecurseEnabled_SQALENotEnabled", resourceCulture);
+                return ResourceManager.GetString("APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled", resourceCulture);
             }
         }
         
@@ -224,6 +233,20 @@ namespace SonarQube.Plugins.Roslyn {
         
         /// <summary>
         ///   Looks up a localized string similar to 
+        ///Rules definitions: a template rules xml file for the analyzer was saved to {0}. To customise the rules definitions for the analyzer:
+        /// * rename the file
+        /// * edit the rules definitions in the file
+        /// * re-run this generator specifying the rules xml file to use with the /rules:[filename] argument.
+        ///.
+        /// </summary>
+        public static string APG_TemplateRuleFileGenerated {
+            get {
+                return ResourceManager.GetString("APG_TemplateRuleFileGenerated", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to 
         ///SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE remediation information for the analyzer:
         /// * rename the file
         /// * fill in the appropriate remediation information for each diagnostic
@@ -242,6 +265,24 @@ namespace SonarQube.Plugins.Roslyn {
         public static string APG_UnsupportedLanguage {
             get {
                 return ResourceManager.GetString("APG_UnsupportedLanguage", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using the supplied rules xml file: {0}.
+        /// </summary>
+        public static string APG_UsingSuppliedRulesFile {
+            get {
+                return ResourceManager.GetString("APG_UsingSuppliedRulesFile", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Using the SQALE file: {0}.
+        /// </summary>
+        public static string APG_UsingSuppliedSqaleFile {
+            get {
+                return ResourceManager.GetString("APG_UsingSuppliedSqaleFile", resourceCulture);
             }
         }
         

--- a/RoslynPluginGenerator/UIResources.resx
+++ b/RoslynPluginGenerator/UIResources.resx
@@ -132,6 +132,9 @@
   <data name="APG_GeneratingRules" xml:space="preserve">
     <value>Generating rules...</value>
   </data>
+  <data name="APG_InvalidRulesFile" xml:space="preserve">
+    <value>The specified rules xml file is invalid: {0}</value>
+  </data>
   <data name="APG_InvalidSqaleFile" xml:space="preserve">
     <value>The specified SQALE file is invalid: {0}</value>
   </data>
@@ -162,14 +165,22 @@
   <data name="APG_PluginGenerated" xml:space="preserve">
     <value>Plugin generated: {0}</value>
   </data>
-  <data name="APG_RecurseEnabled_SQALENotEnabled" xml:space="preserve">
-    <value>SQALE information cannot currently be embedded into plugins generated from package dependencies.</value>
+  <data name="APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled" xml:space="preserve">
+    <value>SQALE and customised rule xml information cannot currently be embedded into plugins generated from package dependencies.</value>
   </data>
   <data name="APG_RulesGeneratedToFile" xml:space="preserve">
     <value>{0} rules generated to {1}</value>
   </data>
   <data name="APG_SqaleGeneratedToFile" xml:space="preserve">
     <value>SQALE generated to file {0}</value>
+  </data>
+  <data name="APG_TemplateRuleFileGenerated" xml:space="preserve">
+    <value>
+Rules definitions: a template rules xml file for the analyzer was saved to {0}. To customise the rules definitions for the analyzer:
+ * rename the file
+ * edit the rules definitions in the file
+ * re-run this generator specifying the rules xml file to use with the /rules:[filename] argument.
+</value>
   </data>
   <data name="APG_TemplateSqaleFileGenerated" xml:space="preserve">
     <value>
@@ -181,6 +192,12 @@ SQALE: an empty SQALE file for the analyzer was saved to {0}. To provide SQALE r
   </data>
   <data name="APG_UnsupportedLanguage" xml:space="preserve">
     <value>The language '{0}' is not supported. Valid options are 'cs' or 'vb'.</value>
+  </data>
+  <data name="APG_UsingSuppliedRulesFile" xml:space="preserve">
+    <value>Using the supplied rules xml file: {0}</value>
+  </data>
+  <data name="APG_UsingSuppliedSqaleFile" xml:space="preserve">
+    <value>Using the SQALE file: {0}</value>
   </data>
   <data name="AssemblyDescription" xml:space="preserve">
     <value>Roslyn Analyzer Plugin Generator for SonarQube</value>

--- a/Tests/CommonTests/SerializationTests.cs
+++ b/Tests/CommonTests/SerializationTests.cs
@@ -44,8 +44,10 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
                     Severity = "CRITICAL",
                     Cardinality = "SINGLE",
                     Status = "READY",
-                   Type = IssueType.CODE_SMELL,
-                    Tags = new[] { "t1", "t2" }
+                    Type = IssueType.CODE_SMELL,
+                    Tags = new[] { "t1", "t2" },
+                    DebtRemediationFunction = DebtRemediationFunctionType.CONSTANT_ISSUE,
+                    DebtRemediationFunctionOffset = "15min"
                 },
 
                 new Rule()
@@ -83,6 +85,8 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
     <type>CODE_SMELL</type>
     <tag>t1</tag>
     <tag>t2</tag>
+    <debtRemediationFunction>CONSTANT_ISSUE</debtRemediationFunction>
+    <debtRemediationFunctionOffset>15min</debtRemediationFunctionOffset>
   </rule>
   <rule>
     <key>key2</key>

--- a/Tests/CommonTests/SerializationTests.cs
+++ b/Tests/CommonTests/SerializationTests.cs
@@ -44,6 +44,7 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
                     Severity = "CRITICAL",
                     Cardinality = "SINGLE",
                     Status = "READY",
+                   Type = IssueType.CODE_SMELL,
                     Tags = new[] { "t1", "t2" }
                 },
 
@@ -55,6 +56,7 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
                     Description = @"<p>An Html <a href=""www.bing.com""> Description",
                     Severity = "MAJOR",
                     Cardinality = "SINGLE",
+                    Type = IssueType.BUG,
                     Status = "READY",
                 }
             };
@@ -78,6 +80,7 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
     <severity>CRITICAL</severity>
     <cardinality>SINGLE</cardinality>
     <status>READY</status>
+    <type>CODE_SMELL</type>
     <tag>t1</tag>
     <tag>t2</tag>
   </rule>
@@ -89,6 +92,7 @@ namespace SonarQube.Plugins.Roslyn.RuleGeneratorTests
     <severity>MAJOR</severity>
     <cardinality>SINGLE</cardinality>
     <status>READY</status>
+    <type>BUG</type>
   </rule>
 </rules>";
 

--- a/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
+++ b/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
@@ -58,7 +58,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir);
+            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, null, false, false, outputDir);
             bool result = apg.Generate(args);
 
             // Assert
@@ -92,7 +92,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false,
+            ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, null, false, 
                 true /* generate plugins for dependencies with analyzers*/, outputDir);
             bool result = apg.Generate(args);
 
@@ -127,7 +127,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false,
+            ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, null, false,
                 true /* generate plugins for dependencies with analyzers*/, outputDir);
             bool result = apg.Generate(args);
 

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -421,7 +421,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             result = apg.Generate(args);
 
             result.Should().BeTrue("Expecting generation to have succeeded");
-            logger.AssertSingleWarningExists(UIResources.APG_RecurseEnabled_SQALENotEnabled);
+            logger.AssertSingleWarningExists(UIResources.APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled);
             AssertSqaleFileExistsForPackage(logger, outputDir, parent);
             AssertSqaleFileExistsForPackage(logger, outputDir, child1);
             AssertSqaleFileExistsForPackage(logger, outputDir, child2);
@@ -481,6 +481,108 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             result.Should().BeFalse("Expecting generation to have failed");
             AssertSqaleTemplateDoesNotExist(outputDir);
             logger.AssertSingleErrorExists("invalidSqale.xml"); // expecting an error containing the invalid sqale file name
+        }
+
+        [TestMethod]
+        public void Generate_RulesFileNotSpecified_TemplateFileCreated()
+        {
+            // Arrange
+            string outputDir = TestUtils.CreateTestDirectory(this.TestContext, ".out");
+
+            var logger = new TestLogger();
+            var remoteRepoBuilder = new RemoteRepoBuilder(this.TestContext);
+            var child1 = CreatePackageWithAnalyzer(remoteRepoBuilder, "child1.requiredAccept.id", "2.1", License.NotRequired);
+            var child2 = CreatePackageWithAnalyzer(remoteRepoBuilder, "child2.id", "2.2", License.NotRequired);
+            var parent = CreatePackageWithAnalyzer(remoteRepoBuilder, "parent.id", "1.0", License.NotRequired, child1, child2);
+
+            var nuGetHandler = new NuGetPackageHandler(remoteRepoBuilder.FakeRemoteRepo, GetLocalNuGetDownloadDir(), logger);
+
+            var testSubject = new AnalyzerPluginGenerator(nuGetHandler, logger);
+
+            // 1. Generate a plugin for the target package only. Expecting a plugin and a template rule file.
+            var args = new ProcessedArgsBuilder("parent.id", outputDir)
+                .SetLanguage("cs")
+                .SetPackageVersion("1.0")
+                .SetRecurseDependencies(true)
+                .Build();
+            bool result = testSubject.Generate(args);
+
+            Assert.IsTrue(result, "Expecting generation to have succeeded");
+            AssertRuleTemplateFileExistsForPackage(logger, outputDir, parent);
+
+            // 2. Generate a plugin for target package and all dependencies. Expecting three plugins and associated rule files.
+            logger.Reset();
+            args = CreateArgs("parent.id", "1.0", "cs", null, false, true /* /recurse = true */, outputDir);
+            result = testSubject.Generate(args);
+
+            Assert.IsTrue(result, "Expecting generation to have succeeded");
+            logger.AssertSingleWarningExists(UIResources.APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled);
+            AssertRuleTemplateFileExistsForPackage(logger, outputDir, parent);
+            AssertRuleTemplateFileExistsForPackage(logger, outputDir, child1);
+            AssertRuleTemplateFileExistsForPackage(logger, outputDir, child2);
+        }
+
+        [TestMethod]
+        public void Generate_ValidRuleFileSpecified_TemplateFileNotCreated()
+        {
+            // Arrange
+            var outputDir = TestUtils.CreateTestDirectory(this.TestContext, ".out");
+
+            var remoteRepoBuilder = new RemoteRepoBuilder(this.TestContext);
+            var apg = CreateTestSubjectWithFakeRemoteRepo(remoteRepoBuilder);
+
+            CreatePackageInFakeRemoteRepo(remoteRepoBuilder, "dummy.id", "1.1");
+
+            // Create a dummy rule file
+            var dummyRuleFilePath = Path.Combine(outputDir, "inputRule.xml");
+            Serializer.SaveModel(new Rules(), dummyRuleFilePath);
+
+            var args = new ProcessedArgsBuilder("dummy.id", outputDir)
+                .SetLanguage("cs")
+                .SetPackageVersion("1.1")
+                .SetRuleFilePath(dummyRuleFilePath)
+                .Build();
+
+            // Act
+            bool result = apg.Generate(args);
+
+            // Assert
+            Assert.IsTrue(result, "Expecting generation to have succeeded");
+            AssertRuleTemplateDoesNotExist(outputDir);
+        }
+
+        [TestMethod]
+        public void Generate_InvalidRuleFileSpecified_GeneratorError()
+        {
+            // Arrange
+            var outputDir = TestUtils.CreateTestDirectory(this.TestContext, ".out");
+
+            var logger = new TestLogger();
+
+            var remoteRepoBuilder = new RemoteRepoBuilder(this.TestContext);
+            CreatePackageInFakeRemoteRepo(remoteRepoBuilder, "dummy.id", "1.1");
+
+            var nuGetHandler = new NuGetPackageHandler(remoteRepoBuilder.FakeRemoteRepo, GetLocalNuGetDownloadDir(), logger);
+
+            // Create an invalid rule file
+            var dummyRuleFilePath = Path.Combine(outputDir, "invalidRule.xml");
+            File.WriteAllText(dummyRuleFilePath, "not valid xml");
+
+            AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
+
+            var args = new ProcessedArgsBuilder("dummy.id", outputDir)
+                .SetLanguage("cs")
+                .SetPackageVersion("1.1")
+                .SetRuleFilePath(dummyRuleFilePath)
+                .Build();
+
+            // Act
+            bool result = apg.Generate(args);
+
+            // Assert
+            Assert.IsFalse(result, "Expecting generation to have failed");
+            AssertRuleTemplateDoesNotExist(outputDir);
+            logger.AssertSingleErrorExists("invalidRule.xml"); // expecting an error containing the invalid rule file name
         }
 
         [TestMethod]
@@ -623,6 +725,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 new SemanticVersion(packageVersion),
                 language,
                 sqaleFilePath,
+                null /* rule xml path */,
                 acceptLicenses,
                 recurseDependencies,
                 outputDirectory);
@@ -684,7 +787,27 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
         private static void AssertSqaleTemplateDoesNotExist(string outputDir)
         {
             string[] matches = Directory.GetFiles(outputDir, "*sqale*template*", SearchOption.AllDirectories);
-            matches.Length.Should().Be(0, "Not expecting any squale template files to exist");
+            matches.Length.Should().Be(0, "Not expecting any sqale template files to exist");
+        }
+
+        private static string GetExpectedRuleTemplateFilePath(string outputDir, IPackage package)
+        {
+            return Path.Combine(outputDir, String.Format("{0}.{1}.rules.template.xml", package.Id, package.Version.ToString()));
+        }
+
+        private void AssertRuleTemplateFileExistsForPackage(TestLogger logger, string outputDir, IPackage package)
+        {
+            string expectedFilePath = GetExpectedRuleTemplateFilePath(outputDir, package);
+
+            Assert.IsTrue(File.Exists(expectedFilePath), "Expecting a template rule file to have been created");
+            this.TestContext.AddResultFile(expectedFilePath);
+            logger.AssertSingleInfoMessageExists(expectedFilePath); // should be a message about the generated file
+        }
+
+        private static void AssertRuleTemplateDoesNotExist(string outputDir)
+        {
+            string[] matches = Directory.GetFiles(outputDir, "*rules*template*", SearchOption.AllDirectories);
+            Assert.AreEqual(0, matches.Length, "Not expecting any rules template files to exist");
         }
 
         private static void AssertJarsGenerated(string rootDir, int expectedCount)

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -580,7 +580,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             bool result = apg.Generate(args);
 
             // Assert
-            Assert.IsFalse(result, "Expecting generation to have failed");
+            result.Should().BeFalse();
             AssertRuleTemplateDoesNotExist(outputDir);
             logger.AssertSingleErrorExists("invalidRule.xml"); // expecting an error containing the invalid rule file name
         }
@@ -807,7 +807,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
         private static void AssertRuleTemplateDoesNotExist(string outputDir)
         {
             string[] matches = Directory.GetFiles(outputDir, "*rules*template*", SearchOption.AllDirectories);
-            Assert.AreEqual(0, matches.Length, "Not expecting any rules template files to exist");
+            matches.Length.Should().Be(0, "Not expecting any rules template files to exist");
         }
 
         private static void AssertJarsGenerated(string rootDir, int expectedCount)

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -18,14 +18,14 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System;
-using System.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet;
 using SonarLint.XmlDescriptor;
 using SonarQube.Plugins.Roslyn.CommandLine;
 using SonarQube.Plugins.Test.Common;
+using System;
+using System.IO;
 using static SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.RemoteRepoBuilder;
 
 namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
@@ -506,16 +506,16 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 .SetRecurseDependencies(true)
                 .Build();
             bool result = testSubject.Generate(args);
+            result.Should().BeTrue();
 
-            Assert.IsTrue(result, "Expecting generation to have succeeded");
             AssertRuleTemplateFileExistsForPackage(logger, outputDir, parent);
 
             // 2. Generate a plugin for target package and all dependencies. Expecting three plugins and associated rule files.
             logger.Reset();
             args = CreateArgs("parent.id", "1.0", "cs", null, false, true /* /recurse = true */, outputDir);
             result = testSubject.Generate(args);
+            result.Should().BeTrue();
 
-            Assert.IsTrue(result, "Expecting generation to have succeeded");
             logger.AssertSingleWarningExists(UIResources.APG_RecurseEnabled_SQALEandRuleCustomisationNotEnabled);
             AssertRuleTemplateFileExistsForPackage(logger, outputDir, parent);
             AssertRuleTemplateFileExistsForPackage(logger, outputDir, child1);
@@ -547,7 +547,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             bool result = apg.Generate(args);
 
             // Assert
-            Assert.IsTrue(result, "Expecting generation to have succeeded");
+            result.Should().BeTrue();
             AssertRuleTemplateDoesNotExist(outputDir);
         }
 
@@ -799,7 +799,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
         {
             string expectedFilePath = GetExpectedRuleTemplateFilePath(outputDir, package);
 
-            Assert.IsTrue(File.Exists(expectedFilePath), "Expecting a template rule file to have been created");
+            File.Exists(expectedFilePath).Should().BeTrue();
             this.TestContext.AddResultFile(expectedFilePath);
             logger.AssertSingleInfoMessageExists(expectedFilePath); // should be a message about the generated file
         }

--- a/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArchiveUpdaterTests.cs
@@ -18,11 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.IO;
-using System.IO.Compression;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using SonarQube.Plugins.Test.Common;
+using System.IO;
+using System.IO.Compression;
 
 namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
 {
@@ -97,7 +97,7 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 AddEntry(archive, "sub/changed", "original data in file that is going to be changed to something shorted");
             }
 
-            Assert.IsTrue(File.Exists(originalZipFile), "Test setup error: original zip file not created");
+            File.Exists(originalZipFile).Should().BeTrue("Test setup error: original zip file not created");
 
             string changedFile = TestUtils.CreateTextFile("changed.txt", rootTestDir, "new data in changed file");
             string newFile = TestUtils.CreateTextFile("newfile.txt", rootTestDir, "new file");

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -18,12 +18,11 @@
  * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
  */
 
-using System.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
-using FluentAssertions;
 using SonarQube.Plugins.Roslyn.CommandLine;
 using SonarQube.Plugins.Test.Common;
+using System.IO;
 
 namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
 {

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -21,6 +21,7 @@
 using System.IO;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using FluentAssertions;
 using SonarQube.Plugins.Roslyn.CommandLine;
 using SonarQube.Plugins.Test.Common;
 
@@ -146,6 +147,41 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
             actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
 
             AssertArgumentsProcessed(actualArgs, logger, "valid", "1.0", filePath, false);
+        }
+
+        [TestMethod]
+        public void ArgProc_RuleFile()
+        {
+            // 0. Setup
+            TestLogger logger;
+            string[] rawArgs;
+            ProcessedArgs actualArgs;
+
+            // 1. No rule file value -> valid
+            logger = new TestLogger();
+            rawArgs = new string[] { "/a:validId" };
+            actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.RuleFilePath.Should().BeNull();
+
+            // 2. Missing rule file
+            logger = new TestLogger();
+            rawArgs = new string[] { "/rules:missingFile.txt", "/a:validId" };
+            actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            AssertArgumentsNotProcessed(actualArgs, logger);
+            logger.AssertSingleErrorExists("missingFile.txt"); // should be an error containing the missing file name
+
+            // 3. Existing rule file
+            string testDir = TestUtils.CreateTestDirectory(this.TestContext);
+            string filePath = TestUtils.CreateTextFile("valid.rules.txt", testDir, "rule file contents");
+
+            logger = new TestLogger();
+            rawArgs = new string[] { $"/rules:{filePath}", "/a:valid:1.0" };
+            actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.Should().NotBeNull();
+            actualArgs.RuleFilePath.Should().Be(filePath);
         }
 
         [TestMethod]

--- a/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
+++ b/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
@@ -25,20 +25,21 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
 {
     public class ProcessedArgsBuilder
     {
-        private string packageId;
+        private readonly string packageId;
         private string packageVersion;
         private string language;
         private string sqaleFilePath;
         private string ruleFilePath;
         private bool acceptLicenses;
         private bool recurseDependencies;
-        private string outputDirectory;
+        private readonly string outputDirectory;
 
         public ProcessedArgsBuilder(string packageId, string outputDir)
         {
             this.packageId = packageId;
             this.outputDirectory = outputDir;
         }
+
         public ProcessedArgsBuilder SetPackageVersion(string packageVersion)
         {
             this.packageVersion = packageVersion;

--- a/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
+++ b/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
@@ -1,0 +1,92 @@
+﻿/*
+ * SonarQube Roslyn SDK
+ * Copyright (C) 2015-2018 SonarSource SA
+ * mailto:info AT sonarsource DOT com
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3 of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this program; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+using NuGet;
+using SonarQube.Plugins.Roslyn.CommandLine;
+
+namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
+{
+    public class ProcessedArgsBuilder
+    {
+        private string packageId;
+        private string packageVersion;
+        private string language;
+        private string sqaleFilePath;
+        private string ruleFilePath;
+        private bool acceptLicenses;
+        private bool recurseDependencies;
+        private string outputDirectory;
+
+        public ProcessedArgsBuilder(string packageId, string outputDir)
+        {
+            this.packageId = packageId;
+            this.outputDirectory = outputDir;
+        }
+        public ProcessedArgsBuilder SetPackageVersion(string packageVersion)
+        {
+            this.packageVersion = packageVersion;
+            return this;
+        }
+
+        public ProcessedArgsBuilder SetLanguage(string language)
+        {
+            this.language = language;
+            return this;
+        }
+
+        public ProcessedArgsBuilder SetSqaleFilePath(string filePath)
+        {
+            this.sqaleFilePath = filePath;
+            return this;
+        }
+
+        public ProcessedArgsBuilder SetRuleFilePath(string filePath)
+        {
+            this.ruleFilePath = filePath;
+            return this;
+        }
+
+        public ProcessedArgsBuilder SetAcceptLicenses(bool acceptLicenses)
+        {
+            this.acceptLicenses = acceptLicenses;
+            return this;
+        }
+
+        public ProcessedArgsBuilder SetRecurseDependencies(bool recurseDependencies)
+        {
+            this.recurseDependencies = recurseDependencies;
+            return this;
+        }
+
+        public ProcessedArgs Build()
+        {
+            ProcessedArgs args = new ProcessedArgs(
+                packageId,
+                new SemanticVersion(packageVersion),
+                language,
+                sqaleFilePath,
+                ruleFilePath,
+                acceptLicenses,
+                recurseDependencies,
+                outputDirectory);
+            return args;
+        }
+    }
+}

--- a/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
+++ b/Tests/RoslynPluginGeneratorTests/SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests.csproj
@@ -38,6 +38,9 @@
     <Reference Include="FluentAssertions, Version=5.4.1.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
       <HintPath>..\..\packages\FluentAssertions.5.4.1\lib\net45\FluentAssertions.dll</HintPath>
     </Reference>
+    <Reference Include="Castle.Core, Version=4.0.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\Castle.Core.4.2.1\lib\net45\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="Microsoft.CodeAnalysis, Version=1.1.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\..\packages\Microsoft.CodeAnalysis.Common.1.1.0\lib\net45\Microsoft.CodeAnalysis.dll</HintPath>
       <Private>True</Private>
@@ -94,6 +97,7 @@
       <HintPath>..\..\packages\Microsoft.Composition.1.0.27\lib\portable-net45+win8+wp8+wpa81\System.Composition.TypedParts.dll</HintPath>
       <Private>True</Private>
     </Reference>
+    <Reference Include="System.Configuration" />
     <Reference Include="System.IO.Compression" />
     <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Reflection.Metadata, Version=1.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
@@ -102,6 +106,9 @@
     </Reference>
     <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>..\..\packages\System.ValueTuple.4.4.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Threading.Tasks.Extensions, Version=4.1.0.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\..\packages\System.Threading.Tasks.Extensions.4.3.0\lib\portable-net45+win8+wp8+wpa81\System.Threading.Tasks.Extensions.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml" />
     <Reference Include="System.Xml.Linq" />
@@ -126,6 +133,7 @@
     <Compile Include="NuGetMachineWideSettingsTests.cs" />
     <Compile Include="NuGetRepositoryFactoryTests.cs" />
     <Compile Include="Infrastructure\RemoteRepoBuilder.cs" />
+    <Compile Include="ProcessedArgsBuilder.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="..\..\AssemblyInfo.Shared.cs">
       <Link>Properties\AssemblyInfo.Shared.cs</Link>


### PR DESCRIPTION
The code follows the same pattern used for customizing SQALE i.e.
* first time the exe is called, a template _rules.xml_ is created
* the user can customize the file, then run the exe again using the _/rules_ parameter to tell the exe to use the customized rules file