### PR TITLE
Add new command line parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,7 +105,8 @@ The SDK will look for NuGet.config files in the following locations:
 - %ProgramData%\NuGet\Config\SonarQube (a custom machine-wide location
 - %ProgramData%\NuGet\Config (i.e. the standard machine-wide location)
 
-If the analyzer you want to package is available in a private NuGet feed then you will need to create an appropriate NuGet.config file to point to the private feed.
+If the analyzer you want to package is available in a private NuGet feed then you will need to create an appropriate NuGet.config file to point to the private feed. Alternatively you can use the `/customnugetrepo:file:///PathToRepo` 
+parameter. This will overwrite the above mentioned NuGet behaviour.
 
 #### Generating a jar for an analyzer that is not available from a NuGet feed
 If you want to create a jar for Roslyn analyzer that is not available from a NuGet feed (e.g. an analyzer you have created on your local machine) you can specify a package source that points at a local directory containing the *.nupkg* file created by the standard Roslyn templates. See the [NuGet docs](https://docs.nuget.org/create/hosting-your-own-nuget-feeds) for more information.

--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ e.g. */a:Wintellect.Analyzers:1.0.5.0*
 
 The tool will create a .jar file named after the package name and version in the current directory
 e.g. *wintellectanalyzers-plugin-1.0.5.jar*
+You can specify the output directory with the `/o:PathToOutputDir` command line parameter.
 
 The generated jar can be installed to SonarQube as normal (e.g. by dropping it in the SonarQube server *extensions\plugins* folder and restarting the SonarQube server).
 You will see a new repository containing all of the rules defined by the analyzer. The rules can be added to Quality Profiles just like any other SonarQube rule.

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -42,6 +42,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             public const string RuleXmlFile = "rules.xml";
             public const string AcceptLicenses = "accept.licenses";
             public const string RecurseDependencies = "recurse.dependencies";
+            public const string OutputDirectory = "output.dir";
         }
 
         private static IList<ArgumentDescriptor> Descriptors;
@@ -61,7 +62,9 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 new ArgumentDescriptor(
                     id: KeywordIds.AcceptLicenses, prefixes: new string[] { "/acceptLicenses" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_AcceptLicenses, isVerb: true),
                 new ArgumentDescriptor(
-                    id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true)
+                    id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true),
+                new ArgumentDescriptor(
+                    id: KeywordIds.OutputDirectory, prefixes: new string[] { "/ouputdir:", "/o:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_OutputDirectory)
             };
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
@@ -120,6 +123,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
 
             bool acceptLicense = GetLicenseAcceptance(arguments);
             bool recurseDependencies = GetRecursion(arguments);
+            string outputDirectory = GetOutputDirectory(arguments);
 
             if (parsedOk)
             {
@@ -131,7 +135,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     ruleFilePath,
                     acceptLicense,
                     recurseDependencies,
-                    System.IO.Directory.GetCurrentDirectory());
+                    outputDirectory);
             }
 
             return processed;
@@ -220,6 +224,18 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 this.logger.LogError(CmdLineResources.ERROR_RuleFileNotFound, arg.Value);
             }
             return success;
+        }
+
+        private string GetOutputDirectory(IEnumerable<ArgumentInstance> arguments)
+        {
+            ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.OutputDirectory, a.Descriptor.Id));
+
+            if (arg != null)
+            {
+                return arg.Value;
+            }
+
+            return Directory.GetCurrentDirectory();
         }
 
         private static bool GetLicenseAcceptance(IEnumerable<ArgumentInstance> arguments)

--- a/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
+++ b/RoslynPluginGenerator/CommandLine/ArgumentProcessor.cs
@@ -43,6 +43,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             public const string AcceptLicenses = "accept.licenses";
             public const string RecurseDependencies = "recurse.dependencies";
             public const string OutputDirectory = "output.dir";
+            public const string CustomNuGetRepository = "custom.nugetrepo";
         }
 
         private static IList<ArgumentDescriptor> Descriptors;
@@ -64,7 +65,9 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 new ArgumentDescriptor(
                     id: KeywordIds.RecurseDependencies, prefixes: new string[] { "/recurse" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_RecurseDependencies, isVerb: true),
                 new ArgumentDescriptor(
-                    id: KeywordIds.OutputDirectory, prefixes: new string[] { "/ouputdir:", "/o:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_OutputDirectory)
+                    id: KeywordIds.OutputDirectory, prefixes: new string[] { "/ouputdir:", "/o:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDescription_OutputDirectory),
+                new ArgumentDescriptor(
+                    id: KeywordIds.CustomNuGetRepository, prefixes: new string[] { "/customnugetrepo:" }, required: false, allowMultiple: false, description: CmdLineResources.ArgDesciption_CustomNuGetRepo)
             };
 
             Debug.Assert(Descriptors.All(d => d.Prefixes != null && d.Prefixes.Any()), "All descriptors must provide at least one prefix");
@@ -124,6 +127,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             bool acceptLicense = GetLicenseAcceptance(arguments);
             bool recurseDependencies = GetRecursion(arguments);
             string outputDirectory = GetOutputDirectory(arguments);
+            string nuGetRepository = GetNuGetRepository(arguments);
 
             if (parsedOk)
             {
@@ -135,7 +139,8 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                     ruleFilePath,
                     acceptLicense,
                     recurseDependencies,
-                    outputDirectory);
+                    outputDirectory,
+                    nuGetRepository);
             }
 
             return processed;
@@ -224,6 +229,13 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
                 this.logger.LogError(CmdLineResources.ERROR_RuleFileNotFound, arg.Value);
             }
             return success;
+        }
+
+        private string GetNuGetRepository(IEnumerable<ArgumentInstance> arguments)
+        {
+            ArgumentInstance arg = arguments.SingleOrDefault(a => ArgumentDescriptor.IdComparer.Equals(KeywordIds.CustomNuGetRepository, a.Descriptor.Id));
+
+            return arg?.Value;
         }
 
         private string GetOutputDirectory(IEnumerable<ArgumentInstance> arguments)

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -79,6 +79,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /o:[PathToOutputDirectory] Specifies where the jar file should be put.
+        /// </summary>
+        internal static string ArgDescription_OutputDirectory {
+            get {
+                return ResourceManager.GetString("ArgDescription_OutputDirectory", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /recurse - search for analyzers in target package and any dependencies.
         /// </summary>
         internal static string ArgDescription_RecurseDependencies {

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.Designer.cs
@@ -61,6 +61,15 @@ namespace SonarQube.Plugins.Roslyn.CommandLine {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to /customnugetrepo:[Path/Url to Repo] - overwrites default nuget behaviour and only uses this repository..
+        /// </summary>
+        internal static string ArgDesciption_CustomNuGetRepo {
+            get {
+                return ResourceManager.GetString("ArgDesciption_CustomNuGetRepo", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to /acceptLicenses - indicates that you accept the licenses for any packages that required license acceptance.
         /// </summary>
         internal static string ArgDescription_AcceptLicenses {

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -117,6 +117,9 @@
   <resheader name="writer">
     <value>System.Resources.ResXResourceWriter, System.Windows.Forms, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089</value>
   </resheader>
+  <data name="ArgDesciption_CustomNuGetRepo" xml:space="preserve">
+    <value>/customnugetrepo:[Path/Url to Repo] - overwrites default nuget behaviour and only uses this repository.</value>
+  </data>
   <data name="ArgDescription_AcceptLicenses" xml:space="preserve">
     <value>/acceptLicenses - indicates that you accept the licenses for any packages that required license acceptance</value>
   </data>

--- a/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
+++ b/RoslynPluginGenerator/CommandLine/CmdLineResources.resx
@@ -123,6 +123,9 @@
   <data name="ArgDescription_AnalzyerRef" xml:space="preserve">
     <value>/a:[NuGet package id]  or  /a:[NuGet package id]:[version]</value>
   </data>
+  <data name="ArgDescription_OutputDirectory" xml:space="preserve">
+    <value>/o:[PathToOutputDirectory] Specifies where the jar file should be put</value>
+  </data>
   <data name="ArgDescription_RecurseDependencies" xml:space="preserve">
     <value>/recurse - search for analyzers in target package and any dependencies</value>
   </data>

--- a/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
+++ b/RoslynPluginGenerator/CommandLine/ProcessedArgs.cs
@@ -26,7 +26,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
     public class ProcessedArgs
     {
         public ProcessedArgs(string packageId, SemanticVersion packageVersion, string language, string ruleFilePath,
-            bool acceptLicenses, bool recurseDependencies, string outputDirectory)
+            bool acceptLicenses, bool recurseDependencies, string outputDirectory, string customNuGetRepository)
         {
             if (string.IsNullOrWhiteSpace(packageId))
             {
@@ -46,6 +46,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
             AcceptLicenses = acceptLicenses;
             RecurseDependencies = recurseDependencies;
             OutputDirectory = outputDirectory;
+            CustomNuGetRepository = customNuGetRepository;
         }
 
         public string PackageId { get; }
@@ -61,5 +62,7 @@ namespace SonarQube.Plugins.Roslyn.CommandLine
         public bool RecurseDependencies { get; }
 
         public string OutputDirectory { get; }
+
+		public string CustomNuGetRepository { get; }
     }
 }

--- a/RoslynPluginGenerator/NuGet/NuGetRepositoryFactory.cs
+++ b/RoslynPluginGenerator/NuGet/NuGetRepositoryFactory.cs
@@ -20,8 +20,12 @@
 
 using System;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
+using System.Reflection;
 using NuGet;
+using SonarQube.Plugins.Common;
+using SonarQube.Plugins.Roslyn.CommandLine;
 
 namespace SonarQube.Plugins.Roslyn
 {
@@ -86,6 +90,27 @@ namespace SonarQube.Plugins.Roslyn
             aggRepo.Logger = new NuGetLoggerAdapter(logger);
 
             return aggRepo;
+        }
+
+        /// <summary>
+        /// Creates a NuGet repo depending on the given command line arguments for the customnugetrepo path.
+        /// </summary>
+        public static IPackageRepository CreateRepositoryForArguments(ConsoleLogger logger, ProcessedArgs processedArgs)
+        {
+            IPackageRepository repo;
+
+            if (string.IsNullOrWhiteSpace(processedArgs.CustomNuGetRepository))
+            {
+                string exeDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
+                ISettings nuGetSettings = GetSettingsFromConfigFiles(exeDir);
+                repo = CreateRepository(nuGetSettings, logger);
+            }
+            else
+            {
+                repo = PackageRepositoryFactory.Default.CreateRepository(processedArgs.CustomNuGetRepository);
+            }
+
+            return repo;
         }
     }
 }

--- a/RoslynPluginGenerator/Program.cs
+++ b/RoslynPluginGenerator/Program.cs
@@ -47,11 +47,9 @@ namespace SonarQube.Plugins.Roslyn
             bool success = false;
             if (processedArgs != null)
             {
-                string exeDir = Path.GetDirectoryName(Assembly.GetEntryAssembly().Location);
-                ISettings nuGetSettings = NuGetRepositoryFactory.GetSettingsFromConfigFiles(exeDir);
-                IPackageRepository repo = NuGetRepositoryFactory.CreateRepository(nuGetSettings, logger);
                 string localNuGetCache = Utilities.CreateTempDirectory(".nuget");
-                NuGetPackageHandler packageHandler = new NuGetPackageHandler(repo, localNuGetCache, logger);
+                var repo = NuGetRepositoryFactory.CreateRepositoryForArguments(logger, processedArgs);
+                var packageHandler = new NuGetPackageHandler(repo, localNuGetCache, logger);
 
                 AnalyzerPluginGenerator generator = new AnalyzerPluginGenerator(packageHandler, logger);
                 success = generator.Generate(processedArgs);

--- a/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
+++ b/Tests/IntegrationTests/Roslyn/RoslynGenTests.cs
@@ -59,7 +59,7 @@ namespace SonarQube.Plugins.IntegrationTests
             // Act
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir);
+            ProcessedArgs args = new ProcessedArgs(packageId, new SemanticVersion("1.0.2"), "cs", null, false, false, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -94,7 +94,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false, 
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -129,7 +129,7 @@ namespace SonarQube.Plugins.IntegrationTests
             NuGetPackageHandler nuGetHandler = new NuGetPackageHandler(fakeRemotePkgMgr.LocalRepository, localPackageDestination, logger);
             AnalyzerPluginGenerator apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
             ProcessedArgs args = new ProcessedArgs(targetPkg.Id, targetPkg.Version, "cs", null, false,
-                true /* generate plugins for dependencies with analyzers*/, outputDir);
+                true /* generate plugins for dependencies with analyzers*/, outputDir, null);
             bool result = apg.Generate(args);
 
             // Assert
@@ -239,7 +239,7 @@ namespace SonarQube.Plugins.IntegrationTests
             var nuGetHandler = new NuGetPackageHandler(localRepoWithRemotePackage, localPackageDestination, logger);
 
             var apg = new AnalyzerPluginGenerator(nuGetHandler, logger);
-            var args = new ProcessedArgs(packageId, version, "cs", null, false, false, outputDir);
+            var args = new ProcessedArgs(packageId, version, "cs", null, false, false, outputDir, null);
             var result = apg.Generate(args);
 
             // Assert

--- a/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/AnalyzerPluginGeneratorTests.cs
@@ -635,7 +635,8 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 null /* rule xml path */,
                 acceptLicenses,
                 recurseDependencies,
-                outputDirectory);
+                outputDirectory,
+                null);
             return args;
         }
 

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -209,6 +209,28 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
             AssertArgumentsNotProcessed(actualArgs, logger);
         }
 
+        [TestMethod]
+        public void ArgProc_OutputDirectory_Parameter()
+        {
+            var logger = new TestLogger();
+            var rawArgs = new string[] { "/a:validId", "/o:My/Output/Directory" };
+
+            var actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.OutputDirectory.Should().Be("My/Output/Directory");
+        }
+
+        [TestMethod]
+        public void ArgProc_OutputDirectory_Default()
+        {
+            var logger = new TestLogger();
+            var rawArgs = new string[] { "/a:validId" };
+
+            var actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.OutputDirectory.Should().Be(Directory.GetCurrentDirectory());
+        }
+
         #endregion Tests
 
         #region Checks

--- a/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/ArgumentProcessorTests.cs
@@ -231,6 +231,28 @@ namespace SonarQube.Plugins.Roslyn.PluginGeneratorTests
             actualArgs.OutputDirectory.Should().Be(Directory.GetCurrentDirectory());
         }
 
+        [TestMethod]
+        public void ArgProc_CustomNuGetRepository_Default()
+        {
+            var logger = new TestLogger();
+            var rawArgs = new string[] { "/a:validId" };
+
+            var actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.CustomNuGetRepository.Should().BeNull();
+        }
+
+        [TestMethod]
+        public void ArgProc_CustomNuGetRepository_Path()
+        {
+            var logger = new TestLogger();
+            var rawArgs = new string[] { "/a:validId", "/customnugetrepo:file:///somelocalrepo/path" };
+
+            var actualArgs = ArgumentProcessor.TryProcessArguments(rawArgs, logger);
+
+            actualArgs.CustomNuGetRepository.Should().Be("file:///somelocalrepo/path");
+        }
+
         #endregion Tests
 
         #region Checks

--- a/Tests/RoslynPluginGeneratorTests/NuGetRepositoryFactoryTests.cs
+++ b/Tests/RoslynPluginGeneratorTests/NuGetRepositoryFactoryTests.cs
@@ -23,6 +23,7 @@ using System.Linq;
 using FluentAssertions;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
 using NuGet;
+using SonarQube.Plugins.Common;
 using SonarQube.Plugins.Test.Common;
 
 namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
@@ -153,6 +154,22 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             logger.AssertSingleWarningExists(NuGetLoggerAdapter.LogMessagePrefix, "http://bad.remote.unreachable.repo");
             logger.AssertWarningsLogged(1);
             logger.AssertErrorsLogged(0);
+        }
+
+        [TestMethod]
+        public void RepoFactory_GetRepositoryForArguments_CustomNuGetRepo_Overwrites_Default()
+        {
+            var settings = new ProcessedArgsBuilder("SomePackage", "SomeoutDir")
+                .SetCustomNuGetRepository("file:///customrepo/path")
+                .SetPackageVersion("0.0.1")
+                .SetLanguage("cs")
+                .Build();
+            var logger = new ConsoleLogger();
+
+            var repo = NuGetRepositoryFactory.CreateRepositoryForArguments(logger, settings);
+
+            repo.Should().BeOfType<LazyLocalPackageRepository>();
+            repo.Source.Should().Be("/customrepo/path");
         }
 
         #endregion Tests

--- a/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
+++ b/Tests/RoslynPluginGeneratorTests/ProcessedArgsBuilder.cs
@@ -32,6 +32,8 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
         private bool acceptLicenses;
         private bool recurseDependencies;
         private readonly string outputDirectory;
+        private string customNuGetRepo;
+
 
         public ProcessedArgsBuilder(string packageId, string outputDir)
         {
@@ -69,6 +71,12 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
             return this;
         }
 
+        public ProcessedArgsBuilder SetCustomNuGetRepository(string repoUri)
+        {
+            this.customNuGetRepo = repoUri;
+            return this;
+        }
+
         public ProcessedArgs Build()
         {
             ProcessedArgs args = new ProcessedArgs(
@@ -78,7 +86,8 @@ namespace SonarQube.Plugins.Roslyn.RoslynPluginGeneratorTests
                 ruleFilePath,
                 acceptLicenses,
                 recurseDependencies,
-                outputDirectory);
+                outputDirectory,
+                customNuGetRepo);
             return args;
         }
     }


### PR DESCRIPTION
Added new command line parameters that allow more control over how to retrieve packages and where to put the result of the generator.

We wanted to build our roslyn analyzers and in the next step create the sonar plugin without publishing the nuget packages. Also we use the Cake build system and the tool management where it is not good practice to use the working directory of the tool to output the result.

Therefor two new parameters were introduced:
- `/o`: or alternatively `/outputdir:` to specify where to generate the plugin to. The main work was already available in the source, but the parameter was never read from the cli but always defined as the current working directory.
- `/customnugetrepo:file:///PathToRepo` to overwrite the default nuget configuration files. This is helpful when a local nuget source directory is not available at the time of the restore. This is the case when building with Cake, which uses the projects nuget.config file - same as the default implementation of the Plugin generator. With this parameter you can explicitly specify another directory or url for the plugin generation without affecting other nuget processes that need the nuget.config files.

The changes are backward compatible: If not supplied, the previous behaviour is used.