### PR TITLE
Removed COMReference

### DIFF
--- a/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
+++ b/RoslynPluginGenerator/SonarQube.Plugins.Roslyn.PluginGenerator.csproj
@@ -69,15 +69,4 @@
     <ProjectReference Include="..\RoslynV1Resfs\RoslynV1Refs.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <COMReference Include="Shell32">
-      <Guid>{50A7E9B0-70EF-11D1-B75A-00A0C90564FE}</Guid>
-      <VersionMajor>1</VersionMajor>
-      <VersionMinor>0</VersionMinor>
-      <Lcid>0</Lcid>
-      <WrapperTool>tlbimp</WrapperTool>
-      <Isolated>False</Isolated>
-      <EmbedInteropTypes>True</EmbedInteropTypes>
-    </COMReference>
-  </ItemGroup>
 </Project>


### PR DESCRIPTION
Historically, a COM function was used to zip the archive.
Changed in this commit: c8e79cd45a6a2a635e286e028257c35848d896fe 01 August 2018