### PR TITLE
NET-3807 Set explicit check-sca project key metadata

### DIFF
--- a/.github/repo-metadata.yaml
+++ b/.github/repo-metadata.yaml
@@ -1,0 +1,2 @@
+check-sca:
+  project-key: sonarqube-roslyn-sdk


### PR DESCRIPTION
Part of 
<!--
  Only for standalone PRs without Jira issue in the PR title:
    * Replace this comment with Epic ID to create a new Task in Jira
    * Replace this comment with Issue ID to create a new Sub-Task in Jira
    * Ignore or delete this note to create a new Task in Jira without a parent
-->

----
## Summary by Gitar

- **Configuration:**
  - Added `.github/repo-metadata.yaml` to specify the project key for `check-sca` as `sonarqube-roslyn-sdk`.

<sub>This will update automatically on new commits.</sub>