### PR TITLE
CLP-21 Move repository ownership to Core Languages and Parsers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-.github/CODEOWNERS @SonarSource/quality-dotnet-squad
+.github/CODEOWNERS @SonarSource/code-quality-core-languages-parsers-squad


### PR DESCRIPTION
----
## Summary by Gitar

- **Code ownership:**
  - Update `CODEOWNERS` file to transfer repository ownership to `@SonarSource/code-quality-core-languages-parsers-squad`.

<sub>This will update automatically on new commits.</sub>