### PR TITLE
NET-3960 Use squad Renovate preset

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,21 +2,5 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
-  ],
-  "rebaseWhen": "conflicted",
-  "minimumReleaseAgeBehaviour": "timestamp-required",
-  "packageRules": [
-    {
-      "description": "Group GitHub Actions updates",
-      "matchManagers": ["github-actions"],
-      "groupName": "GitHub Actions dependencies",
-      "groupSlug": "github-actions-dependencies"
-    },
-    {
-      "description": "Group NuGet updates",
-      "matchManagers": ["nuget"],
-      "groupName": "NuGet dependencies",
-      "groupSlug": "nuget-dependencies"
-    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,21 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
+  ],
+  "rebaseWhen": "conflicted",
+  "minimumReleaseAgeBehaviour": "timestamp-required",
+  "packageRules": [
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions dependencies",
+      "groupSlug": "github-actions-dependencies"
+    },
+    {
+      "description": "Group NuGet updates",
+      "matchManagers": ["nuget"],
+      "groupName": "NuGet dependencies",
+      "groupSlug": "nuget-dependencies"
+    }
   ]
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>SonarSource/renovate-config"
+    "local>SonarSource/core-languages-tooling-public:renovate-config"
   ]
 }


### PR DESCRIPTION
This switches the repository from the SonarSource root Renovate preset to the squad preset in `SonarSource/core-languages-tooling-public:renovate-config` and keeps only repo-specific overrides.

## Effective Delta After Merge
<!-- codex-effective-delta:start -->
- onboarding Renovate
<!-- codex-effective-delta:end -->
