### PR TITLE
CLP-11 Exclude Microsoft.CodeAnalysis* packages from Renovate

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "local>SonarSource/core-languages-tooling-public:renovate-config"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "Microsoft.CodeAnalysis*"
+      ],
+      "enabled": false
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- disable Renovate updates for packages matching `Microsoft.CodeAnalysis*`

## Why
Pavel flagged in #266 that these dependency update PRs are invalid for this repository and must be excluded.

## Validation
- `npx -y --package renovate renovate-config-validator`